### PR TITLE
Fix a bug in tau_estimation()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+./build
+./pyleoclim.egg-info
+./.ipynb_checkpoints
+.ropeproject/
+.DS_Store
+

--- a/Documentation/Spectral.rst
+++ b/Documentation/Spectral.rst
@@ -1,0 +1,17 @@
+Spectral Functions
+====================
+
+This module allows the wavelet analysis and spectral analysis of timeseries.
+
+.. autofunction:: pyleoclim.Spectral.wwz
+
+.. autofunction:: pyleoclim.Spectral.wwz2psd
+
+.. autofunction:: pyleoclim.Spectral.wwz_psd
+
+.. autofunction:: pyleoclim.Spectral.plot_wwa
+
+.. autofunction:: pyleoclim.Spectral.plot_wwadist
+
+.. autofunction:: pyleoclim.Spectral.plot_psd
+

--- a/pyleoclim.egg-info/SOURCES.txt
+++ b/pyleoclim.egg-info/SOURCES.txt
@@ -1,6 +1,15 @@
 README.txt
 setup.cfg
 setup.py
+./pyleoclim/LipdUtils.py
+./pyleoclim/Map.py
+./pyleoclim/Plot.py
+./pyleoclim/Spectral.py
+./pyleoclim/Stats.py
+./pyleoclim/SummaryPlots.py
+./pyleoclim/Timeseries.py
+./pyleoclim/__init__.py
+./pyleoclim/f2py_wwz.cpython-36m-darwin.so
 pyleoclim/LipdUtils.py
 pyleoclim/Map.py
 pyleoclim/Plot.py
@@ -12,6 +21,7 @@ pyleoclim/__init__.py
 pyleoclim.egg-info/PKG-INFO
 pyleoclim.egg-info/SOURCES.txt
 pyleoclim.egg-info/dependency_links.txt
+pyleoclim.egg-info/not-zip-safe
 pyleoclim.egg-info/pbr.json
 pyleoclim.egg-info/requires.txt
 pyleoclim.egg-info/top_level.txt

--- a/pyleoclim.egg-info/requires.txt
+++ b/pyleoclim.egg-info/requires.txt
@@ -1,4 +1,4 @@
-LiPD>=0.2.0.2, <0.2.0.3
+LiPD>=0.2.0.2
 pandas>=0.19.2
 numpy>=1.12.1
 matplotlib>=2.0.0

--- a/pyleoclim/__init__.py
+++ b/pyleoclim/__init__.py
@@ -17,7 +17,7 @@ from mpl_toolkits.basemap import Basemap
 from matplotlib import gridspec
 import seaborn as sns
 
-#Import internal modules to pyleoclim
+# Import internal modules to pyleoclim
 from pyleoclim import Map
 from pyleoclim import LipdUtils
 from pyleoclim import SummaryPlots
@@ -26,7 +26,6 @@ from pyleoclim import Spectral
 from pyleoclim import Stats
 from pyleoclim import Timeseries
 
-
 """
 Get the LiPD files and set a few global variables
 """
@@ -34,21 +33,21 @@ Get the LiPD files and set a few global variables
 # Load the LiPDs present in the directory
 def openLipds(path="",ts_list=""):
     """Load and extract timeseries objects from LiPD files.
-    
+
     Allows to load and extract timeseries objects into the workspace for use
-    with Pyleoclim. This can be done by the user previously, using the LiPD 
+    with Pyleoclim. This can be done by the user previously, using the LiPD
     utilities and passed into the function's argumenta. If no timeseries objects
     are found by other functions, this function will be triggered automatically
     without arguments.
-    
-    Args:  
-        path (string): the path to the LiPD file. If not specified, will 
-            trigger the LiPD utilities GUI.
-        ts_list (list): the list of available timeseries objects 
-            obtained from lipd.extractTs(). 
 
-    Warning: 
-        if specifying a list, path should also be specified. 
+    Args:
+        path (string): the path to the LiPD file. If not specified, will
+            trigger the LiPD utilities GUI.
+        ts_list (list): the list of available timeseries objects
+            obtained from lipd.extractTs().
+
+    Warning:
+        if specifying a list, path should also be specified.
 
     """
     global lipd_path
@@ -63,8 +62,8 @@ def openLipds(path="",ts_list=""):
         sys.exit("If specifying a list of timeseries, also need to specify path")
     else:
         lipd_path = path
-        timeseries_list = ts_list       
-        
+        timeseries_list = ts_list
+
 # Set the default palette for plots
 
 plot_default = {'ice/rock': ['#FFD600','h'],
@@ -75,49 +74,49 @@ plot_default = {'ice/rock': ['#FFD600','h'],
                 'lake sediment': ['#4169E0','s'],
                 'marine sediment': ['#8A4513', 's'],
                 'sclerosponge' : ['r','o'],
-                'speleothem' : ['#FF1492','d'], 
+                'speleothem' : ['#FF1492','d'],
                 'wood' : ['#32CC32','^'],
                 'molluskshells' : ['#FFD600','h'],
-                'peat' : ['#2F4F4F','*']} 
+                'peat' : ['#2F4F4F','*']}
 
-""" 
+"""
 Mapping
 """
 def mapAllArchive(markersize = 50, background = 'shadedrelief',\
                   saveFig = False, dir="", format='eps'):
     """Map all the available records loaded into the workspace by archiveType.
-    
-    Map of all the records into the workspace by archiveType. 
-        Uses the default color palette. Enter pyleoclim.plot_default for detail. 
-    
+
+    Map of all the records into the workspace by archiveType.
+        Uses the default color palette. Enter pyleoclim.plot_default for detail.
+
     Args:
         markersize (int): The size of the markers. Default is 50
-        background (str): Plots one of the following images on the map: 
-            bluemarble, etopo, shadedrelief, or none (filled continents). 
+        background (str): Plots one of the following images on the map:
+            bluemarble, etopo, shadedrelief, or none (filled continents).
             Default is shadedrelief.
         saveFig (bool): Default is to not save the figure
-        dir (str): The absolute path of the directory in which to save the 
-            figure. If not provided, creates a default folder called 'figures' 
-            in the LiPD working directory (lipd.path). 
-        format (str): One of the file extensions supported by the active 
+        dir (str): The absolute path of the directory in which to save the
+            figure. If not provided, creates a default folder called 'figures'
+            in the LiPD working directory (lipd.path).
+        format (str): One of the file extensions supported by the active
             backend. Default is "eps". Most backend support png, pdf, ps, eps,
-            and svg. 
-    
+            and svg.
+
     Returns:
-        The figure    
+        The figure
     """
     # Make sure there are LiPD files to plot
     if not 'timeseries_list' in globals():
         openLipds()
-    
+
     #Get the lipd files
     lipd_in_directory = lpd.getLipdNames()
-    
+
     # Initialize the various lists
     lat = []
     lon = []
     archiveType = []
-    
+
     # Loop ang grab the metadata
     for lipd in lipd_in_directory:
         d = lpd.getMetadata(lipd)
@@ -126,24 +125,24 @@ def mapAllArchive(markersize = 50, background = 'shadedrelief',\
         archiveType.append(LipdUtils.LipdToOntology(d['archiveType']).lower())
 
     # append the default palette for other category
-    plot_default.update({'other':['k','o']}) 
-    
+    plot_default.update({'other':['k','o']})
+
     # make sure criteria is in the plot_default list
     for idx,val in enumerate(archiveType):
         if val not in plot_default.keys():
             archiveType[idx] = 'other'
-            
-    
+
+
     # Make the map
     fig = Map.mapAll(lat,lon,archiveType,lat_0=0,lon_0=0,palette=plot_default,\
                      background = background, markersize = markersize)
-    
+
     # Save the figure if asked
     if saveFig == True:
         LipdUtils.saveFigure('mapLipds_archive', format, dir)
     else:
         plt.show
-    
+
     return fig
 
 def mapLipd(timeseries="", countries = True, counties = False, \
@@ -151,59 +150,59 @@ def mapLipd(timeseries="", countries = True, counties = False, \
         scale = 0.5, markersize = 50, marker = "ro", \
         saveFig = False, dir = "", format="eps"):
     """ Create a Map for a single record
-    
+
     Orthographic projection map of a single record.
-    
+
     Args:
         timeseries: a LiPD timeseries object. Will prompt for one if not given
         countries (bool): Draws the country borders. Default is on (True).
         counties (bool): Draws the USA counties. Default is off (False).
         rivers (bool): Draws the rivers. Default is off (False).
-        states (bool): Draws the American and Australian states borders. 
+        states (bool): Draws the American and Australian states borders.
             Default is off (False)
-        background (str): Plots one of the following images on the map: 
-            bluemarble, etopo, shadedrelief, or none (filled continents). 
+        background (str): Plots one of the following images on the map:
+            bluemarble, etopo, shadedrelief, or none (filled continents).
             Default is shadedrelief
-        scale (float): useful to downgrade the original image resolution to 
+        scale (float): useful to downgrade the original image resolution to
             speed up the process. Default is 0.5.
         markersize (int): default is 50
         marker (str): a string (or list) containing the color and shape of the
             marker. Default is by archiveType. Type pyleo.plot_default to see
-            the default palette. 
+            the default palette.
         saveFig (bool): default is to not save the figure
         dir (str): the full path of the directory in which to save the figure.
             If not provided, creates a default folder called 'figures' in the
-            LiPD working directory (lipd.path).  
-        format (str): One of the file extensions supported by the active 
+            LiPD working directory (lipd.path).
+        format (str): One of the file extensions supported by the active
             backend. Default is "eps". Most backend support png, pdf, ps, eps,
             and svg.
-        
+
     Returns:
         The figure
-                      
+
     """
     # Make sure there are LiPD files to plot
     if not 'timeseries_list' in globals():
         openLipds()
-        
+
     if not timeseries:
         timeseries = LipdUtils.getTs(timeseries_list)
-    
+
     # Get latitude/longitude
 
-    lat = timeseries['geo_meanLat']    
+    lat = timeseries['geo_meanLat']
     lon = timeseries['geo_meanLon']
-    
+
     # Get the marker color and shape
     archiveType = LipdUtils.LipdToOntology(timeseries['archiveType']).lower()
-    
+
     # Make sure it's in the palette
     if marker == 'default':
         archiveType = LipdUtils.LipdToOntology(timeseries["archiveType"])
         marker = plot_default[archiveType]
     else:
         marker = 'ro'
-    
+
     fig = Map.mapOne(lat,lon,marker=marker,markersize=markersize,\
                      countries = countries, counties = counties,rivers = rivers, \
                      states = states, background = background, scale =scale)
@@ -213,7 +212,7 @@ def mapLipd(timeseries="", countries = True, counties = False, \
         LipdUtils.saveFigure(timeseries['dataSetName']+'_map', format, dir)
     else:
         plt.show
-    
+
     return fig
 
 """
@@ -223,50 +222,50 @@ Plotting
 def plotTs(timeseries = "", x_axis = "", markersize = 50,\
             marker = "default", saveFig = False, dir = "",\
             format="eps"):
-    """Plot a single time series. 
-    
+    """Plot a single time series.
+
     Args:
-        A timeseries: By default, will prompt the user for one. 
+        A timeseries: By default, will prompt the user for one.
         x_axis (str): The representation against which to plot the paleo-data.
-            Options are "age", "year", and "depth". Default is to let the 
-            system choose if only one available or prompt the user. 
-        markersize (int): default is 50. 
+            Options are "age", "year", and "depth". Default is to let the
+            system choose if only one available or prompt the user.
+        markersize (int): default is 50.
         marker (str): a string (or list) containing the color and shape of the
-            marker. Default is by archiveType. Type pyleo.plot_default to see 
+            marker. Default is by archiveType. Type pyleo.plot_default to see
             the default palette.
         saveFig (bool): default is to not save the figure
         dir (str): the full path of the directory in which to save the figure.
-            If not provided, creates a default folder called 'figures' in the 
-            LiPD working directory (lipd.path). 
-        format (str): One of the file extensions supported by the active 
+            If not provided, creates a default folder called 'figures' in the
+            LiPD working directory (lipd.path).
+        format (str): One of the file extensions supported by the active
             backend. Default is "eps". Most backend support png, pdf, ps, eps,
             and svg.
-    
+
     Returns:
-        The figure. 
-        
+        The figure.
+
     """
     # Get the timeseries dictionary if not in global variables
     if not 'timeseries_list' in globals():
         openLipds()
-    
-    # Get a timeseries if not already provided    
+
+    # Get a timeseries if not already provided
     if not timeseries:
         timeseries = LipdUtils.getTs(timeseries_list)
-    
-    y = np.array(timeseries['paleoData_values'], dtype = 'float64')   
+
+    y = np.array(timeseries['paleoData_values'], dtype = 'float64')
     x, label = LipdUtils.checkXaxis(timeseries, x_axis=x_axis)
-    
+
     # remove nans
     index = np.where(~np.isnan(y))[0]
     x = x[index]
     y = y[index]
-    
+
     # get the markers
     if marker == "default":
         archiveType = LipdUtils.LipdToOntology(timeseries["archiveType"])
         marker = [plot_default[archiveType][0],plot_default[archiveType][1]]
-    
+
     # Get the labels
     # title
     title = timeseries['dataSetName']
@@ -274,30 +273,30 @@ def plotTs(timeseries = "", x_axis = "", markersize = 50,\
     if label+"Units" in timeseries.keys():
         x_label = label[0].upper()+label[1:]+ " ("+timeseries[label+"Units"]+")"
     else:
-        x_label = label[0].upper()+label[1:]   
+        x_label = label[0].upper()+label[1:]
     # ylabel
     if "paleoData_InferredVariableType" in timeseries.keys():
         if "paleoData_units" in timeseries.keys():
             y_label = timeseries["paleoData_InferredVariableType"] + \
-                      " (" + timeseries["paleoData_units"]+")" 
+                      " (" + timeseries["paleoData_units"]+")"
         else:
             y_label = timeseries["paleoData_InferredVariableType"]
     elif "paleoData_ProxyObservationType" in timeseries.keys():
         if "paleoData_units" in timeseries.keys():
             y_label = timeseries["paleoData_ProxyObservationType"] + \
-                      " (" + timeseries["paleoData_units"]+")" 
+                      " (" + timeseries["paleoData_units"]+")"
         else:
             y_label = timeseries["paleoData_ProxyObservationType"]
     else:
         if "paleoData_units" in timeseries.keys():
             y_label = timeseries["paleoData_variableName"] + \
-                      " (" + timeseries["paleoData_units"]+")" 
+                      " (" + timeseries["paleoData_units"]+")"
         else:
-            y_label = timeseries["paleoData_variableName"]            
-                    
+            y_label = timeseries["paleoData_variableName"]
+
     # make the plot
     fig = Plot.plot(x,y,markersize=markersize,marker=marker,x_label=x_label,\
-                    y_label=y_label, title=title)        
+                    y_label=y_label, title=title)
 
     #Save the figure if asked
     if saveFig == True:
@@ -305,8 +304,8 @@ def plotTs(timeseries = "", x_axis = "", markersize = 50,\
             "_"+y_label
         LipdUtils.saveFigure(name,format,dir)
     else:
-        plt.show()        
-        
+        plt.show()
+
     return fig
 
 def histTs(timeseries = "", bins = None, hist = True, \
@@ -316,98 +315,98 @@ def histTs(timeseries = "", bins = None, hist = True, \
              norm_hist = True, saveFig = False, format ="eps",\
              dir = ""):
     """ Plot a univariate distribution of the PaleoData values
-    
+
     This function is based on the seaborn displot function, which is
-    itself a combination of the matplotlib hist function with the 
-    seaborn kdeplot() and rugplot() functions. It can also fit 
+    itself a combination of the matplotlib hist function with the
+    seaborn kdeplot() and rugplot() functions. It can also fit
     scipy.stats distributions and plot the estimated PDF over the data.
-    
+
     Args:
         timeseries: A timeseries. By default, will prompt the user for one.
-        bins (int): Specification of hist bins following matplotlib(hist), 
+        bins (int): Specification of hist bins following matplotlib(hist),
             or None to use Freedman-Diaconis rule
-        hist (bool): Whether to plot a (normed) histogram    
+        hist (bool): Whether to plot a (normed) histogram
         kde (bool): Whether to plot a gaussian kernel density estimate
         rug (bool): Whether to draw a rugplot on the support axis
-        fit: Random variable object. An object with fit method, returning 
-            a tuple that can be passed to a pdf method of positional 
+        fit: Random variable object. An object with fit method, returning
+            a tuple that can be passed to a pdf method of positional
             arguments following a grid of values to evaluate the pdf on.
-        {hist, kde, rug, fit}_kws: Dictionaries. Keyword arguments for 
+        {hist, kde, rug, fit}_kws: Dictionaries. Keyword arguments for
             underlying plotting functions. If modifying the dictionary, make
             sure the labels "hist", "kde", "rug" and "fit" are still passed.
         color (str): matplotlib color. Color to plot everything but the
             fitted curve in. Default is to use the default paletter for each
-            archive type. 
+            archive type.
         vertical (bool): if True, oberved values are on y-axis.
         norm_hist (bool): If True (default), the histrogram height shows
-            a density rather than a count. This is implied if a KDE or 
+            a density rather than a count. This is implied if a KDE or
             fitted density is plotted
         saveFig (bool): default is to not save the figure
         dir (str): the full path of the directory in which to save the figure.
-            If not provided, creates a default folder called 'figures' in the 
-            LiPD working directory (lipd.path). 
-        format (str): One of the file extensions supported by the active 
+            If not provided, creates a default folder called 'figures' in the
+            LiPD working directory (lipd.path).
+        format (str): One of the file extensions supported by the active
             backend. Default is "eps". Most backend support png, pdf, ps, eps,
             and svg.
-            
+
     Returns
         fig - The figure
-  
-    """    
+
+    """
     if not 'timeseries_list' in globals():
         openLipds()
 
     # Get the timeseries if not present
     if not timeseries:
         timeseries = LipdUtils.getTs(timeseries_list)
-    
-    # Get the values    
-    y = np.array(timeseries['paleoData_values'], dtype = 'float64')                 
+
+    # Get the values
+    y = np.array(timeseries['paleoData_values'], dtype = 'float64')
 
     # Remove NaNs
     index = np.where(~np.isnan(y))[0]
     y = y[index]
-    
+
     # Get the y_label
     if "paleoData_InferredVariableType" in timeseries.keys():
         if "paleoData_units" in timeseries.keys():
             y_label = timeseries["paleoData_InferredVariableType"] + \
-                      " (" + timeseries["paleoData_units"]+")" 
+                      " (" + timeseries["paleoData_units"]+")"
         else:
             y_label = timeseries["paleoData_InferredVariableType"]
     elif "paleoData_ProxyObservationType" in timeseries.keys():
         if "paleoData_units" in timeseries.keys():
             y_label = timeseries["paleoData_ProxyObservationType"] + \
-                      " (" + timeseries["paleoData_units"]+")" 
+                      " (" + timeseries["paleoData_units"]+")"
         else:
             y_label = timeseries["paleoData_ProxyObservationType"]
     else:
         if "paleoData_units" in timeseries.keys():
             y_label = timeseries["paleoData_variableName"] + \
-                      " (" + timeseries["paleoData_units"]+")" 
+                      " (" + timeseries["paleoData_units"]+")"
         else:
-            y_label = timeseries["paleoData_variableName"] 
-    
+            y_label = timeseries["paleoData_variableName"]
+
     # Grab the color
     if color == "default":
        archiveType = LipdUtils.LipdToOntology(timeseries["archiveType"])
-       color = plot_default[archiveType][0] 
-    
+       color = plot_default[archiveType][0]
+
     # Make this histogram
     fig = Plot.plot_hist(y, bins = bins, hist = hist, \
              kde = kde, rug = rug, fit = fit, hist_kws = hist_kws,\
              kde_kws = kde_kws, rug_kws = rug_kws, \
              fit_kws = fit_kws, color = color, vertical = vertical, \
              norm_hist = norm_hist, label = y_label)
-    
+
     #Save the figure if asked
     if saveFig == True:
         name = 'plot_timeseries_'+timeseries["dataSetName"]+\
             "_"+y_label
         LipdUtils.saveFigure(name,format,dir)
     else:
-        plt.show()        
-        
+        plt.show()
+
     return fig
 
 """
@@ -417,7 +416,7 @@ SummaryPlots
 def summaryTs(timeseries = "", x_axis = "", saveFig = False, dir = "",
                format ="eps"):
     """Basic summary plot
-    
+
     Plots the following information: the time series, a histogram of
     the PaleoData_values, location map, age-depth profile if both are
     available from the paleodata, metadata about the record.
@@ -436,17 +435,17 @@ def summaryTs(timeseries = "", x_axis = "", saveFig = False, dir = "",
             and svg.
 
     Returns:
-        The figure        
-    
+        The figure
+
     """
-    
+
     if not 'timeseries_list' in globals():
         openLipds()
-    
-    # get a timeseries if none provided     
+
+    # get a timeseries if none provided
     if not timeseries:
         timeseries = LipdUtils.getTs(timeseries_list)
-    
+
     # get the necessary metadata
     metadata = SummaryPlots.getMetadata(timeseries)
 
@@ -460,17 +459,17 @@ def summaryTs(timeseries = "", x_axis = "", saveFig = False, dir = "",
         flag = ""
     else:
         flag = "no age or depth info"
-    
+
     # Make the figure
     fig = plt.figure(figsize=(11,8))
     gs = gridspec.GridSpec(2, 5)
     gs.update(left=0, right =1.1)
-    
+
     # Plot the timeseries
     ax1 = fig.add_subplot(gs[0,:-3])
     marker = [plot_default[archiveType][0],plot_default[archiveType][1]]
     markersize = 50
-    
+
     ax1.scatter(x,y,s = markersize, facecolor = 'none', edgecolor = marker[0],
                 marker = marker[1], label = 'original')
     ax1.plot(x,y, color = marker[0], linewidth = 1, label = 'interpolated')
@@ -480,21 +479,21 @@ def summaryTs(timeseries = "", x_axis = "", saveFig = False, dir = "",
     ymin, ymax = axes.get_ylim()
     plt.title(timeseries['dataSetName'], fontsize = 14, fontweight = 'bold')
     plt.legend(loc=3,scatterpoints=1,fancybox=True,shadow=True,fontsize=10)
-    
+
     # Plot the histogram and kernel density estimates
     ax2 = fig.add_subplot(gs[0,2])
     sns.distplot(y, vertical = True, color = marker[0], \
                 hist_kws = {"label":"Histogram"},
                 kde_kws = {"label":"KDE fit"})
-    
+
     plt.xlabel('PDF')
     ax2.set_ylim([ymin,ymax])
     ax2.set_yticklabels([])
-    
+
     # Plot the Map
     lat = timeseries["geo_meanLat"]
     lon = timeseries["geo_meanLon"]
-    
+
     ax3 = fig.add_subplot(gs[1,0])
     map = Basemap(projection='ortho', lon_0=lon, lat_0=lat)
     map.drawcoastlines()
@@ -505,7 +504,7 @@ def summaryTs(timeseries = "", x_axis = "", saveFig = False, dir = "",
                s = 150,
                color = marker[0],
                marker = marker[1])
-    
+
     # Plot Age model if any
     if not flag:
         ax4 = fig.add_subplot(gs[1,2])
@@ -515,7 +514,7 @@ def summaryTs(timeseries = "", x_axis = "", saveFig = False, dir = "",
         plt.ylabel(age_label)
     else:
         print("No age or depth information available, skipping age model plot")
-    
+
     #Add the metadata
     textstr = "archiveType: " + metadata["archiveType"]+"\n"+"\n"+\
               "Authors: " + metadata["authors"]+"\n"+"\n"+\
@@ -531,7 +530,7 @@ def summaryTs(timeseries = "", x_axis = "", saveFig = False, dir = "",
               "Calibration: \n" + \
               "    Equation: " + metadata["Calibration_equation"] + "\n" +\
               "    Notes: " + metadata["Calibration_notes"]
-    plt.figtext(0.7, 0.4, textstr, fontsize = 12)        
+    plt.figtext(0.7, 0.4, textstr, fontsize = 12)
 
     #Save the figure if asked
     if saveFig == True:
@@ -539,8 +538,8 @@ def summaryTs(timeseries = "", x_axis = "", saveFig = False, dir = "",
             "_"+y_label
         LipdUtils.saveFigure(name,format,dir)
     else:
-        plt.show()        
-        
+        plt.show()
+
     return fig
 
 """
@@ -549,30 +548,30 @@ Statistics
 
 def statsTs(timeseries=""):
     """ Calculate simple statistics of a timeseries
-    
+
     Args:
         timeseries: sytem will prompt for one if not given
-        
+
     Returns:
         the mean, median, min, max, standard deviation and the
         inter-quartile range (IQR) of a timeseries.
-        
+
     Examples:
         >>> mean, median, min_, max_, std, IQR = pyleo.statsTs(timeseries)
-            
+
     """
     if not 'timeseries_list' in globals():
         openLipds()
-    
+
     # Get the timeseries if not present
     if not timeseries:
         timeseries = LipdUtils.getTs(timeseries_list)
-     
+
     # get the values
-    y = np.array(timeseries['paleoData_values'], dtype = 'float64')     
-    
-    mean, median, min_, max_, std, IQR = Stats.simpleStats(y)    
-     
+    y = np.array(timeseries['paleoData_values'], dtype = 'float64')
+
+    mean, median, min_, max_, std, IQR = Stats.simpleStats(y)
+
     return mean, median, min_, max_, std, IQR
 
 def corrSigTs(timeseries1 = "", timeseries2 = "", x_axis = "", \
@@ -601,9 +600,9 @@ def corrSigTs(timeseries1 = "", timeseries2 = "", x_axis = "", \
                     - 'isopersistant': AR(1) modeling of the two timeseries \n
                     - 'isospectral' (default): phase randomization of original
                     inputs.
-                The T-test is parametric test, hence cheap but usually wrong 
+                The T-test is parametric test, hence cheap but usually wrong
                 except in idyllic circumstances.
-                The others are non-parametric, but their computational 
+                The others are non-parametric, but their computational
                 requirements scales with nsim.
             alpha (float): significance level for critical value estimation. Default is 0.05
 
@@ -611,35 +610,35 @@ def corrSigTs(timeseries1 = "", timeseries2 = "", x_axis = "", \
             r (float) - correlation between the two timeseries \n
             sig (bool) -  Returns True if significant, False otherwise \n
             p (real) - the p-value
-            
-    """    
+
+    """
     if not 'timeseries_list' in globals():
         openLipds()
-    
-    # Get the timeseries    
+
+    # Get the timeseries
     if not timeseries1:
         timeseries1 = LipdUtils.getTs(timeseries_list)
-    
+
     if not timeseries2:
         timeseries2 = LipdUtils.getTs(timeseries_list)
-    
+
     # Get the first time and paleoData values
-    y1 = np.array(timeseries1['paleoData_values'], dtype = 'float64')   
+    y1 = np.array(timeseries1['paleoData_values'], dtype = 'float64')
     x1, label = LipdUtils.checkXaxis(timeseries1, x_axis=x_axis)
-    
+
     # Get the second one
-    y2 = np.array(timeseries2['paleoData_values'], dtype = 'float64')  
+    y2 = np.array(timeseries2['paleoData_values'], dtype = 'float64')
     x2, label = LipdUtils.checkXaxis(timeseries2, x_axis=label)
-    
-    # Remove NaNs 
+
+    # Remove NaNs
     index1 = np.where(~np.isnan(y1))[0]
     x1 = x1[index1]
     y1 = y1[index1]
-    
+
     index2 = np.where(~np.isnan(y2))[0]
     x2 = x2[index2]
     y2 = y2[index2]
-    
+
     #Check that the two timeseries have the same lenght and if not interpolate
     if len(y1) != len(y2):
         print("The two series don't have the same length. Interpolating ...")
@@ -657,47 +656,47 @@ def corrSigTs(timeseries1 = "", timeseries2 = "", x_axis = "", \
         #xi = x1
         interp_values1 = y1
         interp_values2 = y2
-    
-    
-    r, sig, p = Stats.corrsig(interp_values1,interp_values2,nsim=nsim,
-                                 method=method,alpha=alpha)    
 
-    return r, sig, p    
- 
+
+    r, sig, p = Stats.corrsig(interp_values1,interp_values2,nsim=nsim,
+                                 method=method,alpha=alpha)
+
+    return r, sig, p
+
 
 """
 Timeseries manipulation
 """
-   
+
 def binTs(timeseries="", x_axis = "", bin_size = "", start = "", end = ""):
     """Bin the paleoData values of the timeseries
-    
+
     Args:
         timeseries. By default, will prompt the user for one.
         x-axis (str): The representation against which to plot the paleo-data.
-            Options are "age", "year", and "depth". Default is to let the 
-            system  choose if only one available or prompt the user. 
-        bin_size (float): the size of the bins to be used. By default, 
+            Options are "age", "year", and "depth". Default is to let the
+            system  choose if only one available or prompt the user.
+        bin_size (float): the size of the bins to be used. By default,
             will prompt for one
-        start (float): Start time/age/depth. Default is the minimum 
+        start (float): Start time/age/depth. Default is the minimum
         end (float): End time/age/depth. Default is the maximum
-        
+
     Returns:
         binned_values- the binned output,\n
         bins-  the bins (centered on the median, i.e. the 100-200 bin is 150),\n
         n-  number of data points in each bin,\n
         error- the standard error on the mean in each bin\n
-        
+
     """
     if not 'timeseries_list' in globals():
         openLipds()
 
-    # get a timeseries if none provided     
+    # get a timeseries if none provided
     if not timeseries:
         timeseries = LipdUtils.getTs(timeseries_list)
-    
+
     # Get the values
-    y = np.array(timeseries['paleoData_values'], dtype = 'float64')   
+    y = np.array(timeseries['paleoData_values'], dtype = 'float64')
     x, label = LipdUtils.checkXaxis(timeseries, x_axis=x_axis)
 
     #remove nans
@@ -705,57 +704,57 @@ def binTs(timeseries="", x_axis = "", bin_size = "", start = "", end = ""):
     x = x[index]
     y = y[index]
 
-    #Bin the timeseries: 
+    #Bin the timeseries:
     bins, binned_values, n, error = Timeseries.bin(x,y, bin_size = bin_size,\
                                                    start = start, end = end)
-    
+
     return bins, binned_values, n, error
 
 def interpTs(timeseries="", x_axis = "", interp_step = "", start = "", end = ""):
     """Simple linear interpolation
-    
+
     Simple linear interpolation of the data using the numpy.interp method
-    
+
     Args:
         timeseries. Default is blank, will prompt for it
         x-axis (str): The representation against which to plot the paleo-data.
-            Options are "age", "year", and "depth". Default is to let the 
-            system choose if only one available or prompt the user. 
-        interp_step (float): the step size. By default, will prompt the user. 
-        start (float): Start year/age/depth. Default is the minimum 
+            Options are "age", "year", and "depth". Default is to let the
+            system choose if only one available or prompt the user.
+        interp_step (float): the step size. By default, will prompt the user.
+        start (float): Start year/age/depth. Default is the minimum
         end (float): End year/age/depth. Default is the maximum
-        
+
     Returns:
-        interp_age - the interpolated age/year/depth according to the end/start 
+        interp_age - the interpolated age/year/depth according to the end/start
         and time step, \n
         interp_values - the interpolated values
-      
+
     """
     if not 'timeseries_list' in globals():
         openLipds()
-    
-    # get a timeseries if none provided     
+
+    # get a timeseries if none provided
     if not timeseries:
         timeseries = LipdUtils.getTs(timeseries_list)
-        
+
     # Get the values
-    y = np.array(timeseries['paleoData_values'], dtype = 'float64')   
+    y = np.array(timeseries['paleoData_values'], dtype = 'float64')
     x, label = LipdUtils.checkXaxis(timeseries, x_axis=x_axis)
 
     #remove nans
     index = np.where(~np.isnan(y))[0]
     x = x[index]
-    y = y[index]    
+    y = y[index]
 
-    #Interpolate the timeseries    
+    #Interpolate the timeseries
     interp_age, interp_values = Timeseries.interp(x,y,interp_step = interp_step,\
                                                   start= start, end=end)
-    
+
     return interp_age, interp_values
 
 def standardizeTs(timeseries = "", scale = 1, ddof = 0, eps = 1e-3):
-    """ Centers and normalizes the paleoData values of a  given time series. 
-    
+    """ Centers and normalizes the paleoData values of a  given time series.
+
     Constant or nearly constant time series not rescaled.
 
     Args:
@@ -778,23 +777,23 @@ def standardizeTs(timeseries = "", scale = 1, ddof = 0, eps = 1e-3):
     """
     if not 'timeseries_list' in globals():
         openLipds()
-    
-    # get a timeseries if none provided     
+
+    # get a timeseries if none provided
     if not timeseries:
         timeseries = LipdUtils.getTs(timeseries_list)
-        
+
     # get the values
-    y = np.array(timeseries['paleoData_values'], dtype = 'float64') 
-    
+    y = np.array(timeseries['paleoData_values'], dtype = 'float64')
+
     # Remove NaNs
     index = np.where(~np.isnan(y))[0]
     y = y[index]
-    
+
     #Standardize
     z, mu, sig = Timeseries.standardize(y,scale=1,axis=None,ddof=0,eps=1e-3)
-    
+
     return z, mu, sig
-    
+
 
 """
 Wavelet analysis

--- a/setup.py
+++ b/setup.py
@@ -9,25 +9,15 @@ version = '0.2.1'
 if sys.argv[-1] == 'publish' or sys.argv[-1] == 'publishtest':
     os.system('pandoc README.md -f markdown -t rst -s -o README.txt')
 
-# Check the version to make sure it's supported
-if sys.version_info.minor == 4:
-    f2py_wwz_filename = './pyleoclim/f2py_wwz.so'
-elif sys.version_info.minor == 5:
-    f2py_wwz_filename = './pyleoclim/f2py_wwz.cpython-35m-darwin.so'
-elif sys.version_info.minor == 6:
-    f2py_wwz_filename = './pyleoclim/f2py_wwz.cpython-36m-darwin.so'
-else:
-    sys.exit('Your python version is not supported!')    
-
 readme_file = io.open('README.txt', encoding='utf-8')
 
 # Choose the right shared library to copy
 if sys.version_info.minor == 4:
-    f2py_wwz_filename = './pyleoclim/f2py_wwz.so'
+    f2py_wwz_filename = 'f2py_wwz.so'
 elif sys.version_info.minor == 5:
-    f2py_wwz_filename = './pyleoclim/f2py_wwz.cpython-35m-darwin.so'
+    f2py_wwz_filename = 'f2py_wwz.cpython-35m-darwin.so'
 elif sys.version_info.minor == 6:
-    f2py_wwz_filename = './pyleoclim/f2py_wwz.cpython-36m-darwin.so'
+    f2py_wwz_filename = 'f2py_wwz.cpython-36m-darwin.so'
 else:
     sys.exit('Your python version is not supported!')
 
@@ -56,7 +46,9 @@ elif sys.argv[-1] == 'publishtest':
 setup(
     name='pyleoclim',
     packages=find_packages(),
+    package_dir={'pyleoclim': './pyleoclim'},
     package_data={'pyleoclim': [f2py_wwz_filename]},
+    zip_safe=False,
     version=version,
     license='GNU Public',
     description='A Python package for paleoclimate data analysis',


### PR DESCRIPTION
The change is as below
```python
-        a_est = optimize.minimize_scalar(ar1_fun, method='brent').x
+        a_est = optimize.minimize_scalar(ar1_fun, bounds=[0, 1], method='bounded').x
```
Now, the estimation of `a` is bounded within [0, 1] and won't give
inproper result for tau estimation.

Besides:
- The `setup.py` has been updated so that if people install it with
`python setup install`, it will not get an `.egg` file but a folder so
that the `.so` file can be imported correctly.

- In `Spectral.py`, in those functions for users: `wwz()` and
`wwz_psd()`, the NaNs in timeseris (along with the time points) will be
deleted automatically if there is any.

- Add `.gitignore`.