### PR TITLE
WIP stub out pandas roundtrip

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -175,9 +175,10 @@ class Series:
             op = operator.sub
         else:
             raise ValueError(f'Expected one of {"prograde", "retrograde"}, got {direction}')
+
         timedelta = self.time * 10**exponent
         years = timedelta.astype('int')
-        seconds = ((timedelta % 1) * tsutils.SECONDS_PER_YEAR).astype('timedelta64[s]')
+        seconds = ((timedelta - timedelta.astype('int')) * tsutils.SECONDS_PER_YEAR).astype('timedelta64[s]')
         
         np_times = op(op(int(datum), years).astype(str).astype('datetime64[s]'), seconds)
         return pd.DatetimeIndex(np_times, name=self.time_name)

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -7,6 +7,8 @@ The Series class describes the most basic objects in Pyleoclim. A Series is a si
 How to create and manipulate such objects is described in a short example below, while `this notebook <https://nbviewer.jupyter.org/github/LinkedEarth/Pyleoclim_util/blob/master/example_notebooks/pyleoclim_ui_tutorial.ipynb>`_ demonstrates how to apply various Pyleoclim methods to Series objects.
 """
 
+import operator
+
 from ..utils import tsutils, plotting, tsmodel, tsbase, mapping, lipdutils
 from ..utils import wavelet as waveutils
 from ..utils import spectral as specutils
@@ -163,6 +165,48 @@ class Series:
             self.mean=np.mean(self.value)
         else:
             self.mean = mean
+    
+    @property
+    def datetime_index(self):
+        datum, exponent, direction = tsutils.time_unit_to_datum_exp_dir(self.time_unit)
+        op = operator.add if direction == 'forward' else operator.sub
+
+        timedelta = self.time * 10**exponent * tsutils.SECONDS_PER_YEAR
+        years = timedelta.astype('int').astype('timedelta64[Y]')
+        seconds = ((timedelta % 1) * tsutils.SECONDS_PER_YEAR).astype('timedelta64[s]')
+        
+        np_times = op(np.datetime64(datum, 's'), years + seconds)
+        return pd.DatetimeIndex(np_times, name=self.time_name)
+    
+    @property
+    def metadata(self):
+        return dict(
+            time_unit = self.time_unit,
+            value_unit = self.value_unit,
+            label = self.label,
+        )
+    
+    @classmethod
+    def from_pandas(cls, ser, metadata):
+        time = tsutils.convert_datetime_index_to_time(ser.index, metadata['time_unit'])
+        return cls(
+            time=time,
+            value=ser.to_numpy(),
+            time_name=ser.index.name,
+            value_name=ser.name,
+            **metadata,
+        )
+    
+    def to_pandas(self):
+        ser = pd.Series(self.value, index=self.datetime_index, name=self.value_name)
+        # Could be a dataclass instead?
+        return (ser, self.metadata)
+    
+    def pandas_method(self, method):
+        ser, metadata = self.to_pandas()
+        result = method(ser)
+        return self.from_pandas(result, **metadata)
+
 
     def convert_time_unit(self, time_unit='years', keep_log=False):
         ''' Convert the time unit of the Series object

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -210,6 +210,8 @@ class Series:
     def pandas_method(self, method):
         ser, metadata = self.to_pandas()
         result = method(ser)
+        if not isinstance(result, pd.Series):
+            raise ValueError('Given method does not return a pandas Series and cannot be applied')
         return self.from_pandas(result, metadata)
 
 

--- a/pyleoclim/utils/tsutils.py
+++ b/pyleoclim/utils/tsutils.py
@@ -49,15 +49,15 @@ from .tsbase import (
 SECONDS_PER_YEAR = 365.25 * 60  * 60 * 24
 
 def time_unit_to_datum_exp_dir(time_unit):
-    if time_unit is None:
+    if time_unit == 'years':
         datum = '0'
         exponent = 0
         direction = 'prograde'
-    elif any(val in time_unit for val in ('ky', 'kyr', 'kyrs', 'kiloyear', 'ka')):
+    elif time_unit in ('ky', 'kyr', 'kyrs', 'kiloyear', 'ka'):
         datum = '1950'
         exponent = 3
         direction = 'retrograde'
-    elif any(val in time_unit for val in ('y', 'yr', 'yrs', 'year', 'year CE', 'years CE', 'year(s) AD')):
+    elif time_unit in ('y', 'yr', 'yrs', 'year', 'year CE', 'years CE', 'year(s) AD'):
         datum = '0'
         exponent = 0
         direction = 'prograde'
@@ -65,15 +65,15 @@ def time_unit_to_datum_exp_dir(time_unit):
         datum = '1950'
         exponent = 0
         direction = 'retrograde'
-    elif any(val in time_unit for val in ('yr BP', 'yrs BP', 'years BP')):
+    elif time_unit in ('yr BP', 'yrs BP', 'years BP'):
         datum ='1950'
         exponent = 0
         direction = 'retrograde'
-    elif any(val in time_unit for val in ('Ma', 'My')):
+    elif time_unit in ('Ma', 'My'):
         datum ='1950'
         exponent = 6
         direction = 'retrograde'
-    elif any(val in time_unit for val in ('Ga', 'Gy')):
+    elif time_unit in ('Ga', 'Gy'):
         datum ='1950'
         exponent = 3
         direction = 'retrograde'
@@ -90,7 +90,7 @@ def convert_datetime_index_to_time(datetime_index, time_unit):
     elif direction == 'retrograde':
         multiplier = -1
     else:
-        raise ValueError('invalid direction')
+        raise ValueError(f'Expected one of {"prograde", "retrograde"}, got {direction}')
     year_diff = (datetime_index.year - int(datum))
     seconds_diff = (datetime_index.to_numpy() - datetime_index.year.astype(str).astype('datetime64[s]').to_numpy()).astype('int')
     diff = year_diff + seconds_diff / SECONDS_PER_YEAR

--- a/pyleoclim/utils/tsutils.py
+++ b/pyleoclim/utils/tsutils.py
@@ -46,6 +46,22 @@ from .tsbase import (
     clean_ts
 )
 
+SECONDS_PER_YEAR = 365.25 * 60  * 60 * 24
+
+def time_unit_to_datum_exp_dir(time_unit):
+    datum = ...
+    exponent = ...
+    direction = ...
+    return (datum, exponent, direction)
+
+def datum_exp_dir_to_time_unit(datum, exponent, direction):
+    time_unit = ...
+    return time_unit
+
+def convert_datetime_index_to_time(datetime_index, time_unit):
+    time = ...
+    return time
+
 def simple_stats(y, axis=None):
     """ Computes simple statistics
 


### PR DESCRIPTION
As discussed with @CommonClimate and @khider 

The functions that still need populating are:
- time_unit_to_datum_exp_dir
- datum_exp_dir_to_time_unit
- convert_datetime_index_to_time

I think this should be possible using the conversion rules defined by @CommonClimate :

> Conversion rules are given here in pseudocode:
> If time_unit contains ‘ky’, ‘kyr’, ‘kyrs’, ‘kiloyear’, or ‘ka’, then:
> Exponent = 3, datum = “1950" (a string, to be converted internally to the datetime index corresponding to Jan 1, 1950 AD), direction = retrograde
> If time_unit contains ‘y’, ‘yr’, ‘yrs’, ‘year’, ‘year CE’ ‘years CE’  or ‘ year(s) AD’, then:
> Exponent = 0, datum = “0” , (or the datetime index corresponding to [year zero](https://en.wikipedia.org/wiki/Year_zero)), direction = prograde.
> If time_unit == “BP”’, then:
> datum = “1950” , direction = retrograde; ask for user input on exponent
> If time_unit contains “yr BP” ,“yrs BP” or “years BP”, then:
> datum = “1950" , direction = retrograde; exponent = 0
> If time_unit contains ‘Ma’ or  ‘My’, direction =” retrograde, datum = “1950”, exponent = 6
> If time_unit contains ‘Ga’ or  ‘Gy’, direction = retrograde, datum = “1950", exponent = 3
> If lower(time_name) contains “age”,  direction = retrograde, datum = “1950", ask for user input on exponent unless it can be guessed from time_unit as above (e.g. “kyr” is also in the string).
>  If lower(time_name) contains “year”
> Exponent = 0, datum = 0 , (or the datetime index corresponding to [year zero](https://en.wikipedia.org/wiki/Year_zero)), direction = prograde.