### PR TITLE
add load_dataset methods

### DIFF
--- a/example_data/metadata.yml
+++ b/example_data/metadata.yml
@@ -1,0 +1,20 @@
+soi:
+  filename: 'soi_data'
+  file_extension: 'csv'
+  pandas_kwargs:
+    skiprows: 0
+    header: 1
+  pyleo_kwargs:
+    time_name: 'Year (CE)'
+    value_name: 'SOI'
+    label: 'Southern Oscillation Index'
+  time_column: 1
+  value_column: 2
+
+nino3:
+  filename: 'wtc_test_data_nino_even'
+  file_extension: 'csv'
+  pandas_kwargs:
+    header: 0
+  time_column: t
+  value_column: nino

--- a/pyleoclim/tests/__init__.py
+++ b/pyleoclim/tests/__init__.py
@@ -7,5 +7,3 @@ Created on 2020-02-25 14:47:14
 
 consider utils for tests
 """
-
-from .examples import load_dataset

--- a/pyleoclim/tests/utils/test_datasets.py
+++ b/pyleoclim/tests/utils/test_datasets.py
@@ -1,0 +1,40 @@
+# from pyleoclim.utils import load_dataset
+import pyleoclim as pyleo
+import pytest
+from pyleoclim import utils
+from pyleoclim.utils import datasets 
+
+TEST_DATASETS = [
+    'soi',
+    'nino3',
+]
+
+
+def test_load_datasets_metadata():
+    """test loading all metadata for all datasets"""
+    meta = datasets.load_datasets_metadata()
+    assert isinstance(meta, dict)
+
+
+def test_available_dataset_names():
+    """test getting available dataset names"""
+    names = datasets.available_dataset_names()
+    assert len(names) > 0
+
+
+@pytest.mark.parametrize('name', TEST_DATASETS)
+def test_get_metadata(name):
+    meta = datasets.get_metadata(name)
+    assert isinstance(meta, dict)
+
+
+def test_get_metadata_invalid_name():
+    """ensure error is raised with an invalid dataset name"""
+    with pytest.raises(RuntimeError, match='Metadata not found'):
+        datasets.get_metadata('invalid_name')
+
+
+@pytest.mark.parametrize('name', TEST_DATASETS)
+def test_load_dataset(name):
+    ts = datasets.load_dataset(name)
+    assert isinstance(ts, pyleo.Series)

--- a/pyleoclim/utils/__init__.py
+++ b/pyleoclim/utils/__init__.py
@@ -22,5 +22,4 @@ from .filter import *
 from .wavelet import *
 from .jsonutils import *
 from .tsbase import *
-
-
+from .datasets import *

--- a/pyleoclim/utils/datasets.py
+++ b/pyleoclim/utils/datasets.py
@@ -1,0 +1,110 @@
+
+
+
+from pathlib import Path 
+import pyleoclim as pyleo
+import yaml
+import pandas as pd
+
+DATA_DIR = Path(__file__).parents[2].joinpath("example_data").resolve()
+METADATA_PATH = DATA_DIR.joinpath('metadata.yml')
+
+
+def load_datasets_metadata(path=METADATA_PATH):
+    """Load datasets metadata yaml file
+    
+    Parameters
+    ----------
+    path: str or pathlib.Path
+        (Optional) path to dataset metadata yaml
+        
+    Returns
+    -------
+    Dictionary of sample dataset metadata
+    """
+    with open(path, "r") as stream:
+        try:
+            return yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+
+def available_dataset_names():
+    """Helper function to easily see what datasets are available to load"""
+    meta = load_datasets_metadata()
+    return list(meta.keys())
+
+
+def get_metadata(name):
+    """Load the metadata for a given dataset. 
+    Note: Available datasets can be seen via `available_dataset_names`
+
+    Parameters
+    ----------
+    name: str
+        name of the dataset
+    
+    Returns
+    -------
+    Dictionary of metadata for this dataset
+    """
+    all_metadata = load_datasets_metadata()
+    metadata = all_metadata.get(name, None)
+    if metadata is None:
+        avail_names = available_dataset_names()
+        raise RuntimeError(f'Metadata not found for dataset {name}. Available dataset names are: {avail_names}')
+    return metadata
+
+def load_dataset(name):
+    """Load example dataset given the nickname
+    
+    Parameters
+    ----------
+    name: str
+        name of the dataset
+    
+    Returns
+    -------
+    pyleoclim_util.Series of the dataset
+    """
+    # load the metadata for this dataset
+    metadata = get_metadata(name)
+    # construct the full path to the file in the data directory
+    path = DATA_DIR.joinpath(f"{metadata['filename']}.{metadata['file_extension']}")
+
+    time_column =  metadata['time_column']
+    value_column = metadata['value_column']
+    pandas_kwargs = metadata.get('pandas_kwargs', {})
+    pyleo_kwargs = metadata.get('pyleo_kwargs', {})
+
+    # if this is a csv
+    if metadata['file_extension'] == 'csv':
+        # load into pandas
+        df = pd.read_csv(path, **pandas_kwargs)
+
+        # use iloc if we're given an int
+        if isinstance(time_column, int):
+            time=df.iloc[:, time_column]
+        # use column name otherwise
+        else:
+            # if its a column
+            if time_column in df.columns:
+                time = df[time_column]
+            else:
+                time = df.Index
+
+        if isinstance(value_column, int):
+            value=df.iloc[:, value_column]
+        else:
+            value = df[value_column]
+
+        # convert to pyleo.Series
+        ts=pyleo.Series(
+            time=time, 
+            value=value,
+            **pyleo_kwargs,
+        )
+    else:
+        raise RuntimeError(f"Unable to load dataset with file extension {metadata['file_extension']}.")
+
+    return ts

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "nitime>=0.9",
         "tabulate>=0.8.9",
         "Unidecode>=1.1.1",
+        "pyyaml",
     ],
     python_requires=">=3.9.0"
 )


### PR DESCRIPTION
Adds a simplified `load_dataset` method. The example data is small and sits in the repo. A metadata.yml file has been added with details on how to load each dataset. To add a new dataset, add the details to the yaml file. Currently the load_dataset method only accepts csv, but its easily extendible. 

The yaml file is fairly self explanatory except for a few details: `paleo_kwargs` are extra kwargs that are passed on to `pyleoclim.Series` constructor, `pandas_kwargs` are extra kwargs that are passed on to the pd.DataFrame constructor. Lastly, the two variables `time_column` and `value_column` indicate the column in the data to find these. I've set it up so that you can specify an int (which will pull the column using `.iloc`) or a str (which will pull using `df[str]`. 

There are helper functions to load the metadata for individual datasets and to discover what datasets are available. 

TODO:
* [ ] add additional datasets 
* [ ] switch over the other tests to use the local data (and this loader) instead of pulling from the internet.

Resolves: https://github.com/LinkedEarth/paleoPandas/issues/21