### PR TITLE
Add extra index to pip install 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,4 +17,4 @@ dependencies:
   - pytest
   - pip:
     - git+https://github.com/LinkedEarth/Pyleoclim_util.git@Development
-    - pandas==2.0.0.dev0+877.g4901410697
+    - "--pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas"


### PR DESCRIPTION
Adds the extra index to the nightly build in the environment file. We've been using this syntax via the CLI, but since it wasn't in the environment.yml, the CI wasn't including it. 

Resolves https://github.com/LinkedEarth/paleoPandas/issues/23