### PR TITLE
Update enviroment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,4 +17,5 @@ dependencies:
   - pytest
   - pip:
     - git+https://github.com/LinkedEarth/Pyleoclim_util.git@Development
-    - "--pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas"
+    - "--pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple"
+    - pandas>=1.9


### PR DESCRIPTION
The extra index line in the `environment.yml` wasn't being parsed properly by conda. It was adding the extra index, but the pandas part was being ignore. 

Also, I had to play around with my specification of the version. I landed on `pandas>=1.9` as a solution. These parts will all be removed once pandas 2.0 is released so I think its fine. 
