### PR TITLE
Fixup TestUISeriesConvertTimeUnit tests

### DIFF
--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -947,7 +947,6 @@ class TestUiSeriesFilter:
         val_diff = ts_bp.value - ts2.value
         assert np.mean(val_diff**2) < 0.1
 
-@pytest.mark.xfail  # wait for Marco to fix the "DateParseError: day is out of range for month: 0, at position 0" error
 class TestUISeriesConvertTimeUnit:
     '''Tests for Series.convert_time_unit'''
 
@@ -961,7 +960,7 @@ class TestUISeriesConvertTimeUnit:
     def test_convert_time_unit_t1(self):
         ts = gen_ts(nt=550, alpha=1.0)
         ts.time_unit = 'nonsense'
-        with pytest.raises(ValueError):
+        with pytest.warns(UserWarning, match=r'Time unit "nonsense" unknown; triggering defaults'):
             ts.convert_time_unit('yr BP')
 
 class TestUISeriesFillNA:

--- a/pyleoclim/utils/tsutils.py
+++ b/pyleoclim/utils/tsutils.py
@@ -120,7 +120,9 @@ def convert_datetime_index_to_time(datetime_index, time_unit, time_name):
         raise ValueError('The provided index is not a proper DatetimeIndex object')
     else:
         year_diff = (datetime_index.year - int(datum))
-        seconds_diff = (datetime_index.to_numpy() - datetime_index.year.astype(str).astype('datetime64[s]').to_numpy()).astype('int')
+        numpy_datetime_index = datetime_index.to_numpy()
+        years_floor = numpy_datetime_index.astype('datetime64[Y]').astype('datetime64[s]')
+        seconds_diff = (numpy_datetime_index - years_floor).astype('int')
         diff = year_diff + seconds_diff / SECONDS_PER_YEAR
         time = multiplier * diff / 10**exponent
 


### PR DESCRIPTION
Modified to do the date arithmetic in numpy directly, then we're sure to not hit anything that's not yet supported in pandas for this part