### PR TITLE
Covariance regularization

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,6 +20,9 @@ authors:
     given-names: "Myron"
   - family-names: "Athreya"
     given-names: "Pratheek"
+  - family-names: "McGibbon"
+    given-names: "Robert"
+    orcid: "https://orcid.org/0000-0003-3337-954X"
 title: "Pyleoclim: A Python package for the analysis and visualization of paleoclimate data"
 version: v0.9.0
 doi: 10.5281/zenodo.1205661

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,4 @@ dependencies:
     - git+https://github.com/LinkedEarth/Pyleoclim_util.git@Development
     - "--pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple"
     - pandas>=1.9
-    - covar>=0.2
+    - covar

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,3 @@ dependencies:
     - git+https://github.com/LinkedEarth/Pyleoclim_util.git@Development
     - "--pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple"
     - pandas>=1.9
-    - covar

--- a/environment.yml
+++ b/environment.yml
@@ -19,3 +19,4 @@ dependencies:
     - git+https://github.com/LinkedEarth/Pyleoclim_util.git@Development
     - "--pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple"
     - pandas>=1.9
+    - covar>=0.2

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -829,37 +829,36 @@ class TestUISeriesSsa():
         '''Test Series.ssa() with var truncation
         '''
         ts = gen_ts(model = 'colored_noise', nt=500, alpha=1.0)
-        res = ts.ssa(trunc='var')
+        ts.ssa(trunc='var')
 
     def test_ssa_t2(self):
         '''Test Series.ssa() with Monte-Carlo truncation
         '''
 
         ts = gen_ts(model = 'colored_noise', nt=500, alpha=1.0)
-        res = ts.ssa(M=60, nMC=10, trunc='mcssa')
+        ts.ssa(M=60, nMC=10, trunc='mcssa')
         
 
     def test_ssa_t3(self):
         '''Test Series.ssa() with Kaiser truncation
         '''
         ts = gen_ts(model = 'colored_noise', nt=500, alpha=1.0)
-        res = ts.ssa(trunc='kaiser')
+        ts.ssa(trunc='kaiser')
         
     def test_ssa_t4(self):
         '''Test Series.ssa() with missing values
         '''
         soi = pyleo.utils.load_dataset('soi')
-        # erase 5% of missing values
+        # erase 20% of values
         n = len(soi.value)        
         missing = np.random.choice(n,np.floor(0.2*n).astype('int'),replace=False)
         soi_m = soi.copy()
         soi_m.value[missing] = np.nan  # put NaNs at the randomly chosen locations
         miss_ssa = soi_m.ssa()
         assert all(miss_ssa.eigvals >= 0)
-        #fig, _ = miss_ssa.screeplot()
-        #pyleo.closefig(fig)
+        assert np.square(miss_ssa.RCseries - soi.value).mean() < 0.25
+        
     
-            
 
     # def test_ssa_t5(self):
     #     '''Test Series.ssa() on Allen&Smith dataset

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -836,25 +836,39 @@ class TestUISeriesSsa():
         '''
 
         ts = gen_ts(model = 'colored_noise', nt=500, alpha=1.0)
-
         res = ts.ssa(M=60, nMC=10, trunc='mcssa')
-        fig, ax = res.screeplot()
-        pyleo.closefig(fig)
+        
 
     def test_ssa_t3(self):
         '''Test Series.ssa() with Kaiser truncation
         '''
         ts = gen_ts(model = 'colored_noise', nt=500, alpha=1.0)
         res = ts.ssa(trunc='kaiser')
-
+        
     def test_ssa_t4(self):
-        '''Test Series.ssa() on Allen&Smith dataset
+        '''Test Series.ssa() with missing values
         '''
-        df = pd.read_csv('https://raw.githubusercontent.com/LinkedEarth/Pyleoclim_util/Development/example_data/mratest.txt',delim_whitespace=True,names=['Total','Signal','Noise'])
-        mra = pyleo.Series(time=df.index, value=df['Total'], value_name='Allen&Smith test data', time_name='Time', time_unit='yr')
-        mraSsa = mra.ssa(nMC=10)
-        fig, ax = mraSsa.screeplot()
-        pyleo.closefig(fig)
+        soi = pyleo.utils.load_dataset('soi')
+        # erase 5% of missing values
+        n = len(soi.value)        
+        missing = np.random.choice(n,np.floor(0.2*n).astype('int'),replace=False)
+        soi_m = soi.copy()
+        soi_m.value[missing] = np.nan  # put NaNs at the randomly chosen locations
+        miss_ssa = soi_m.ssa()
+        assert all(miss_ssa.eigvals >= 0)
+        #fig, _ = miss_ssa.screeplot()
+        #pyleo.closefig(fig)
+    
+            
+
+    # def test_ssa_t5(self):
+    #     '''Test Series.ssa() on Allen&Smith dataset
+    #     '''
+    #     df = pd.read_csv('https://raw.githubusercontent.com/LinkedEarth/Pyleoclim_util/Development/example_data/mratest.txt',delim_whitespace=True,names=['Total','Signal','Noise'])
+    #     mra = pyleo.Series(time=df.index, value=df['Total'], value_name='Allen&Smith test data', time_name='Time', time_unit='yr')
+    #     mraSsa = mra.ssa(nMC=10)
+    #     fig, ax = mraSsa.screeplot()
+    #     pyleo.closefig(fig)
 
 class TestUiSeriesPlot:
     '''Test for Series.plot()

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -856,7 +856,7 @@ class TestUISeriesSsa():
         soi_m.value[missing] = np.nan  # put NaNs at the randomly chosen locations
         miss_ssa = soi_m.ssa()
         assert all(miss_ssa.eigvals >= 0)
-        assert np.square(miss_ssa.RCseries - soi.value).mean() < 0.25
+        assert np.square(miss_ssa.RCseries - soi.value).mean() < 0.3
         
     
 

--- a/pyleoclim/utils/correlation.py
+++ b/pyleoclim/utils/correlation.py
@@ -797,7 +797,9 @@ def prop_alt(pvals, adj_method='mean', adj_args={'edf_lower': 0.8, 'num_steps': 
 
 def cov_shrink_rblw(S, n):
     """Compute a shrinkage estimate of the covariance matrix using
-    the Rao-Blackwellized Ledoit-Wolf estimator described by Chen et al.
+    the Rao-Blackwellized Ledoit-Wolf estimator described by Chen et al. 2011 [1]
+
+    Contributed by `Robert McGibbon <https://rmcgibbo.org/>`_.
 
     Parameters
     ----------
@@ -850,14 +852,18 @@ def cov_shrink_rblw(S, n):
     approximating shrinkage estimator (OAS), but makes some mathematical errors
     during the derivation, and futhermore their example code published with
     the paper does not implement the proposed formulas.
+
     References
     ----------
-    .. [2] Chen, Yilun, Ami Wiesel, and Alfred O. Hero III. "Shrinkage
-       estimation of high dimensional covariance matrices" ICASSP (2009)
-       http://doi.org/10.1109/ICASSP.2009.4960239
+
+    [1]_ Y. Chen, A. Wiesel and A. O. Hero (2011), 
+    Robust Shrinkage Estimation of High-Dimensional Covariance Matrices,
+    IEEE Transactions on Signal Processing, vol. 59, no. 9, pp. 4097-4107, 
+    doi:10.1109/TSP.2011.2138698
+
     See Also
     --------
-    cov_shrink_ss : similar method, using a different shrinkage target, :math:`T`.
+  
     sklearn.covariance.ledoit_wolf : very similar approach using the same
         shrinkage target, :math:`T`, but a different method for estimating the
         shrinkage intensity, :math:`gamma`.

--- a/pyleoclim/utils/correlation.py
+++ b/pyleoclim/utils/correlation.py
@@ -794,3 +794,94 @@ def prop_alt(pvals, adj_method='mean', adj_args={'edf_lower': 0.8, 'num_steps': 
 
     else:
         raise ValueError('Wrong method: {method}!')
+
+def cov_shrink_rblw(S, n):
+    """Compute a shrinkage estimate of the covariance matrix using
+    the Rao-Blackwellized Ledoit-Wolf estimator described by Chen et al.
+
+    Parameters
+    ----------
+    S : array, shape=(n, n)
+        Sample covariance matrix (e.g. estimated with np.cov(X.T))
+
+    n : int
+        Number of data points used in the estimate of S.
+
+    Returns
+    -------
+
+    sigma : array, shape=(p, p)
+        Estimated shrunk covariance matrix
+
+    shrinkage : float
+        The applied covariance shrinkage intensity.
+
+    Notes
+    -----
+
+    This shrinkage estimator takes the form
+    .. math::
+        \hat{\Sigma} = (1-\gamma) \Sigma_{sample} + \gamma T
+    where :math:`\Sigma^{sample}` is the (noisy but unbiased) empirical
+    covariance matrix,
+    .. math::
+        \Sigma^{sample}_{ij} = \frac{1}{n-1} \sum_{k=1}^n
+            (x_{ki} - \bar{x}_i)(x_{kj} - \bar{x}_j),
+    the matrix :math:`T` is the shrinkage target, a less noisy but biased
+    estimator for the covariance, and the scalar :math:`\gamma \in [0, 1]` is
+    the shrinkage intensity (regularization strength). This approaches uses a
+    scaled identity target, :math:`T`:
+    .. math::
+        T = \frac{\mathrm{Tr}(S)}{p} I_p
+    The shrinkage intensity, :math:`\gamma`, is determined using the RBLW
+    estimator from [2]. The formula for :math:`\gamma` is
+    .. math::
+        \gamma = \min(\alpha + \frac{\beta}{U})
+    where :math:`\alpha`, :math:`\beta`, and :math:`U` are
+    .. math::
+        \alpha &= \frac{n-2}{n(n+2)} \\
+        \beta  &= \frac{(p+1)n - 2}{n(n+2)} \\
+        U      &= \frac{p\, \mathrm{Tr}(S^2)}{\mathrm{Tr}^2(S)} - 1
+    One particularly useful property of this estimator is that it's **very
+    fast**, because it doesn't require access to the data matrix at all (unlike
+    :func:`cov_shrink_ss`). It only requires the sample covariance matrix
+    and the number of data points `n`, as sufficient statistics.
+    For reference, note that [2] defines another estimator, called the oracle
+    approximating shrinkage estimator (OAS), but makes some mathematical errors
+    during the derivation, and futhermore their example code published with
+    the paper does not implement the proposed formulas.
+    References
+    ----------
+    .. [2] Chen, Yilun, Ami Wiesel, and Alfred O. Hero III. "Shrinkage
+       estimation of high dimensional covariance matrices" ICASSP (2009)
+       http://doi.org/10.1109/ICASSP.2009.4960239
+    See Also
+    --------
+    cov_shrink_ss : similar method, using a different shrinkage target, :math:`T`.
+    sklearn.covariance.ledoit_wolf : very similar approach using the same
+        shrinkage target, :math:`T`, but a different method for estimating the
+        shrinkage intensity, :math:`gamma`.
+    """
+
+    p = S.shape[0]
+
+    if S.shape[1] != p:
+        raise ValueError('S must be a (p x p) matrix')
+
+    alpha = (n-2)/(n*(n+2))
+    beta = ((p+1)*n - 2) / (n*(n+2))
+
+    trace_S  = 0  # np.trace(S)
+    trace_S2 = 0  # np.trace(S.dot(S))
+
+    for i in range(p):
+        trace_S += S[i,i]
+        for j in range(p):
+            trace_S2 += S[i,j]*S[i,j]
+
+    U = ((p * trace_S2 / (trace_S*trace_S)) - 1)
+    rho = min(alpha + beta/U, 1)
+
+    F = (trace_S / p) * np.eye(p)
+
+    return (1-rho)*np.asarray(S) + rho*F, rho

--- a/pyleoclim/utils/decomposition.py
+++ b/pyleoclim/utils/decomposition.py
@@ -15,8 +15,8 @@ import numpy as np
 #from statsmodels.multivariate.pca import PCA
 from .tsutils import standardize
 from .tsmodel import ar1_sim
+from .correlation import cov_shrink_rblw
 from scipy.linalg import eigh, toeplitz, ishermitian, eig
-import covar
 import warnings
 #from nitime import algorithms as alg
 #import copy
@@ -354,7 +354,7 @@ def ssa(y, M=None, nMC=0, f=0.5, trunc=None, var_thresh = 80):
     nmodes = np.where(np.real(d)>0)[0].size # effective number of modes
     
     if any(d <= np.finfo(d.dtype).eps): # if C is singular
-        Cr, g  = covar.cov_shrink_rblw(C, n=nmodes)  # apply Rao-Blackwellized Ledoit-Wolf estimator 
+        Cr, g  = cov_shrink_rblw(C, n=nmodes)  # apply Rao-Blackwellized Ledoit-Wolf estimator 
         warnings.warn('Ill-conditioned covariance matrix; regularized with shrinkage factor: {:3.2f}'.format(g),stacklevel=2) 
     else:
         Cr = C 

--- a/pyleoclim/utils/decomposition.py
+++ b/pyleoclim/utils/decomposition.py
@@ -3,7 +3,7 @@
 """
 Eigendecomposition methods:
 Singular Spectrum Analysis (SSA). 
-soon: Monte-Carlo Principal Component Analysis, Multi-Channel SSA
+soon: PCA, Monte-Carlo PCA, Multi-Channel SSA
 """
 
 __all__ = [
@@ -17,7 +17,6 @@ from .tsutils import standardize
 from .tsmodel import ar1_sim
 from scipy.linalg import eigh, toeplitz, ishermitian, eig
 import covar
-import sys
 import warnings
 #from nitime import algorithms as alg
 #import copy

--- a/pyleoclim/utils/decomposition.py
+++ b/pyleoclim/utils/decomposition.py
@@ -356,7 +356,7 @@ def ssa(y, M=None, nMC=0, f=0.5, trunc=None, var_thresh = 80):
     
     if any(d <= np.finfo(d.dtype).eps): # if C is singular
         Cr, g  = covar.cov_shrink_rblw(C, n=nmodes)  # apply Rao-Blackwellized Ledoit-Wolf estimator 
-        warnings.warn('Ill-conditioned covariance matrix; regularized with shrinkage factor: {:3.2f}'.format(g)) 
+        warnings.warn('Ill-conditioned covariance matrix; regularized with shrinkage factor: {:3.2f}'.format(g),stacklevel=2) 
     else:
         Cr = C 
     

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,6 @@ setup(
         "tabulate>=0.8.9",
         "Unidecode>=1.1.1",
         "pyyaml",
-        "covar",
-        "cython"
     ],
     python_requires=">=3.10.0"
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
         "tabulate>=0.8.9",
         "Unidecode>=1.1.1",
         "pyyaml",
-        "covar"
+        "covar",
+        "cython"
     ],
     python_requires=">=3.10.0"
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import io
 from setuptools import setup, find_packages
 
 
-version = '1.0.0b'
+version = '1.0.0b0'
 
 # Read the readme file contents into variable
 def read(fname):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     classifiers=[],
     install_requires=[
         "LiPD==0.2.8.8",
-        "pandas>=1.3.0",
+        "pandas>=1.9.0",
         "numpy<=1.24.0",
         "matplotlib>=3.6.0",
         "scipy>=1.9.1",
@@ -46,6 +46,7 @@ setup(
         "tabulate>=0.8.9",
         "Unidecode>=1.1.1",
         "pyyaml",
+        "covar>=0.2"
     ],
-    python_requires=">=3.9.0"
+    python_requires=">=3.10.0"
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "tabulate>=0.8.9",
         "Unidecode>=1.1.1",
         "pyyaml",
-        "covar>=0.2"
+        "covar"
     ],
     python_requires=">=3.10.0"
 )


### PR DESCRIPTION
addresses #312 by ensuring positive semi-definite eigenvalues. The choice of shrinkage factor is a bit of a hack because the number of DOFs in this case was approximated as the number of positive eigenvalues. SSA reconstruction works with a tiny bit of eigenvalue filtering (Kaiser criterion in this case), but for a robust `ssa_interp()` method we'll need a more general choice of truncation and shrinkage factor for the covariance matrix. Anyway, it plugs the hole, for now.

![ssa_rec](https://user-images.githubusercontent.com/13760223/217407156-517d0cbb-c43d-47f1-a21d-cf98548c4faf.png)
