### PR TITLE
Bin gkernel alignment

### DIFF
--- a/pyleoclim/tests/test_utils_tsutils.py
+++ b/pyleoclim/tests/test_utils_tsutils.py
@@ -1,8 +1,10 @@
 
 import pytest
-from pyleoclim.utils import tsutils, tsbase
+
 import numpy as np
 
+from pyleoclim.utils import tsutils, tsbase
+from numpy.testing import assert_array_equal
 
 def test_bin_t0(unevenly_spaced_series):
     res_dict = tsutils.bin(unevenly_spaced_series.time,unevenly_spaced_series.value)
@@ -15,3 +17,23 @@ def test_bin_t1(unevenly_spaced_series):
     res_dict = tsutils.bin(unevenly_spaced_series.time,unevenly_spaced_series.value,evenly_spaced=True)
     t = res_dict['bins']
     assert tsbase.is_evenly_spaced(t)
+
+def test_bin_t2(unevenly_spaced_series):
+    bins = np.arange(0,100,10)
+    res_dict = tsutils.bin(unevenly_spaced_series.time,unevenly_spaced_series.value,bins=bins)
+    t = res_dict['bins']
+    assert_array_equal(t,(bins[1:]+bins[:-1])/2)
+
+def test_gkernel_t0(unevenly_spaced_series):
+    t,v = tsutils.gkernel(unevenly_spaced_series.time,unevenly_spaced_series.value)
+    assert isinstance(t,np.ndarray)
+    assert isinstance(v,np.ndarray)
+
+def test_gkernel_t1(unevenly_spaced_series):
+    t,v = tsutils.gkernel(unevenly_spaced_series.time,unevenly_spaced_series.value)
+    assert tsbase.is_evenly_spaced(t)
+
+def test_gkernel_t2(unevenly_spaced_series):
+    bins = np.arange(0,100,10)
+    t,v = tsutils.gkernel(unevenly_spaced_series.time,unevenly_spaced_series.value,bins=bins)
+    assert_array_equal(t,(bins[1:]+bins[:-1])/2)

--- a/pyleoclim/tests/test_utils_tsutils.py
+++ b/pyleoclim/tests/test_utils_tsutils.py
@@ -24,6 +24,10 @@ def test_bin_t2(unevenly_spaced_series):
     t = res_dict['bins']
     assert_array_equal(t,(bins[1:]+bins[:-1])/2)
 
+@pytest.mark.parametrize('statistic',['mean','std','median','count','sum','min','max'])
+def test_bin_t3(unevenly_spaced_series,statistic):
+    res_dict = tsutils.bin(unevenly_spaced_series.time,unevenly_spaced_series.value,statistic=statistic)
+
 def test_gkernel_t0(unevenly_spaced_series):
     t,v = tsutils.gkernel(unevenly_spaced_series.time,unevenly_spaced_series.value)
     assert isinstance(t,np.ndarray)

--- a/pyleoclim/utils/tsutils.py
+++ b/pyleoclim/utils/tsutils.py
@@ -90,7 +90,7 @@ def simple_stats(y, axis=None):
     return mean, median, min_, max_, std, IQR
 
 
-def bin(x, y, bin_size=None, start=None, stop=None, bins=None, evenly_spaced = True):
+def bin(x, y, bin_size=None, start=None, stop=None, evenly_spaced = True, bins=None):
     """ Bin the values
 
     Parameters
@@ -111,13 +111,13 @@ def bin(x, y, bin_size=None, start=None, stop=None, bins=None, evenly_spaced = T
     stop : float
         When/where to stop binning. Default is the maximum
 
+    evenly_spaced : {True,False}
+        Makes the series evenly-spaced. This option is ignored if bin_size is set to float
+
     bins : array
         The right hand edge of bins to use for binning. 
         Start, stop, bin_size will be ignored if this is passed.
         See scipy.stats.binned_statistic for details.
-
-    evenly_spaced : {True,False}
-        Makes the series evenly-spaced. This option is ignored if bin_size is set to float
 
     Returns
     -------
@@ -144,8 +144,8 @@ def bin(x, y, bin_size=None, start=None, stop=None, bins=None, evenly_spaced = T
     x = np.array(x, dtype='float64')
     y = np.array(y, dtype='float64')
     
-    if bin_size is not None and evenly_spaced == True:
-        warnings.warn('The bin_size has been set, the series may not be evenly_spaced')
+    if (bin_size is not None or bins is not None) and evenly_spaced == True:
+        warnings.warn('The bin_size or bins has been set, the series may not be evenly_spaced')
 
     # Get the bin_size if not available
     if bin_size is None:
@@ -245,7 +245,6 @@ def gkernel(t,y, h = 3.0, step=None,start=None,stop=None, step_style = 'max'):
     
     # Get the uniform time axis.
     tc = np.arange(start,stop+step,step)
-        
 
     kernel = lambda x, s : 1.0/(s*np.sqrt(2*np.pi))*np.exp(-0.5*(x/s)**2)  # define kernel function
 

--- a/pyleoclim/utils/tsutils.py
+++ b/pyleoclim/utils/tsutils.py
@@ -90,7 +90,7 @@ def simple_stats(y, axis=None):
     return mean, median, min_, max_, std, IQR
 
 
-def bin(x, y, bin_size=None, start=None, stop=None, evenly_spaced = True, bins=None):
+def bin(x, y, bin_size=None, start=None, stop=None, evenly_spaced = True, statistic = 'mean', bins=None):
     """ Bin the values
 
     Parameters
@@ -113,6 +113,10 @@ def bin(x, y, bin_size=None, start=None, stop=None, evenly_spaced = True, bins=N
 
     evenly_spaced : {True,False}
         Makes the series evenly-spaced. This option is ignored if bin_size is set to float
+
+    statistic : str
+        Statistic to calculate and return in values. Default is 'mean'.
+        See scipy.stats.binned_statistic for other options.
 
     bins : array
         The right hand edge of bins to use for binning. 
@@ -165,7 +169,7 @@ def bin(x, y, bin_size=None, start=None, stop=None, evenly_spaced = True, bins=N
         bins = np.arange(start, stop + bin_size, bin_size)
 
     # Perform the calculation
-    binned_values = stats.binned_statistic(x=x,values=y,bins=bins,statistic='mean').statistic
+    binned_values = stats.binned_statistic(x=x,values=y,bins=bins,statistic=statistic).statistic
     n = stats.binned_statistic(x=x,values=y,bins=bins,statistic='count').statistic
     error = stats.binned_statistic(x=x,values=y,bins=bins,statistic='std').statistic
 


### PR DESCRIPTION
Align the behavior of bin and gkernel, and make it possible to easily pass bins for custom time axis resampling. Note that I could not use scipy.stats.binned_statistic for both functions because gkernel requires the usage of both the time and value axis when computing bin values, which the scipy function does not allow for. That being said, the way each function calculates bin edges should now be identical. 

I considered using the same piece of code for both functions, but using the scipy code for the bin function makes it much more flexible in terms of what statistic can be calculated over the bins, which could be very valuable.