### PR TITLE
use UDUNITS seconds_per_year

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -207,6 +207,16 @@ class Series:
        
     @property
     def datetime_index(self):
+        """
+        Convert time to pandas DatetimeIndex.
+
+        Note: conversion will happen using `time_unit`, and will assume:
+
+        - the number of seconds per year is calculated using UDUNITS, see
+          http://cfconventions.org/cf-conventions/cf-conventions#time-coordinate
+        - `time` refers to the Gregorian calendar. If using a different calendar,
+          then please make sure to do any conversions before hand.
+        """
         datum, exponent, direction = tsbase.time_unit_to_datum_exp_dir(self.time_unit)
         index = tsbase.time_to_datetime(self.time, datum, exponent, direction)
         return pd.DatetimeIndex(index, name='datetime')
@@ -268,8 +278,6 @@ class Series:
         ser : pd.Series representation of the pyleo.Series object
 
         '''
-        # Could be a dataclass instead?
-
         ser = pd.Series(self.value, index=self.datetime_index, name=self.value_name)
         if paleo_style:
             time_label, value_label = self.make_labels()

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -1023,9 +1023,10 @@ class TestResample:
         result =ts.resample(rule).mean()
         result_ser = result.to_pandas()
         expected_values = np.array([0., 1., 2., 3., 4.])
-        expected_idx = pd.DatetimeIndex(['2018-12-30 23:59:59', '2019-12-30 23:59:59',
-               '2020-12-30 23:59:59', '2021-12-30 23:59:59',
-               '2022-12-30 23:59:59'], name='datetime').as_unit('s')
+        expected_idx = pd.DatetimeIndex(
+            ['2018-12-31', '2019-12-31', '2020-12-31', '2021-12-31', '2022-12-31'],
+            name='datetime'
+        ).as_unit('s')
         expected_ser = pd.Series(expected_values, expected_idx, name='SOI')
         expected_metadata = {
             'time_unit': 'years CE',
@@ -1049,9 +1050,9 @@ class TestResample:
     @pytest.mark.parametrize(
         ('rule', 'expected_idx'),
         [
-            ('1ga', [np.datetime64('2018-12-30 23:59:59'), np.datetime64('1000002018-12-31 00:00:01')]),
-            ('1ma', [np.datetime64('2018-12-30 23:59:59'), np.datetime64('1002018-12-30 23:59:59')]),
-            ('2ka', [np.datetime64('2018-12-30 23:59:59'), np.datetime64('4018-12-30 23:59:59')]),
+            ('1ga', [np.datetime64('2018-12-31'), np.datetime64('1000002018-12-31')]),
+            ('1ma', [np.datetime64('2018-12-31'), np.datetime64('1002018-12-31')]),
+            ('2ka', [np.datetime64('2018-12-31'), np.datetime64('4018-12-31')]),
         ]
     )
     def test_resample_long_periods(self, rule, expected_idx, dataframe_dt, metadata):
@@ -1128,5 +1129,4 @@ class TestUISeriesEquals():
         soi_pd.index = soi_pd.index + pd.DateOffset(1)
         soi2 = pyleo.Series.from_pandas(soi_pd, soi.metadata)
         same_data, _ = soi.equals(soi2, index_tol= 1.1*86400)
-
         assert same_data

--- a/pyleoclim/tests/test_utils_tsbase.py
+++ b/pyleoclim/tests/test_utils_tsbase.py
@@ -82,8 +82,12 @@ def test_convert_datetime_index_ka(dataframe_dt):
         time_unit, 
         time_name=time_name,
         )
-    expected = np.array([-0.06899658, -0.06999658, -0.07099932, -0.07199658, -0.07299658])
+    expected = np.array([-0.06899805, -0.06999739, -0.07099946, -0.0719988 , -0.07299814])
     assert np.allclose(time.values, expected, rtol=1e-05, atol=1e-08)
+
+    # check we can round-trip
+    result = tsbase.time_to_datetime(time.values, 1950, 3, 'retrograde')
+    assert np.abs(dataframe_dt.index - result).total_seconds().max() <= 1
 
 
 def test_convert_datetime_index_ma(dataframe_dt):
@@ -97,6 +101,10 @@ def test_convert_datetime_index_ma(dataframe_dt):
     expected = np.array([-6.89965777e-05, -6.99965777e-05, -7.09993155e-05, -7.19965777e-05, -7.29965777e-05])
     assert np.allclose(time.values, expected, rtol=1e-05, atol=1e-08)
 
+    # check we can round-trip
+    result = tsbase.time_to_datetime(time.values, 1950, 6, 'retrograde')
+    assert np.abs(dataframe_dt.index - result).total_seconds().max() <= 1
+
 
 def test_convert_datetime_index_ga(dataframe_dt):
     time_unit = 'ga'
@@ -109,6 +117,10 @@ def test_convert_datetime_index_ga(dataframe_dt):
     expected = np.array([-6.89965777e-08, -6.99965777e-08, -7.09993155e-08, -7.19965777e-08, -7.29965777e-08])
     assert np.allclose(time.values, expected, rtol=1e-05, atol=1e-08)
 
+    # check we can round-trip
+    result = tsbase.time_to_datetime(time.values, 1950, 9, 'retrograde')
+    assert np.abs(dataframe_dt.index - result).total_seconds().max() <= 1
+
 
 def test_convert_datetime_index_bp(dataframe_dt):
     time_unit = 'years B.P.'
@@ -118,8 +130,12 @@ def test_convert_datetime_index_bp(dataframe_dt):
         time_unit, 
         time_name=time_name,
         )
-    expected = np.array([-68.99657769, -69.99657769, -70.99931554, -71.99657769, -72.99657769])
+    expected = np.array([-68.99805139, -69.99738827, -70.99946306, -71.99879994, -72.99813682])
     assert np.allclose(time.values, expected, rtol=1e-05, atol=1e-08)
+
+    # check we can round-trip
+    result = tsbase.time_to_datetime(time.values, 1950, 0, 'retrograde')
+    assert np.abs(dataframe_dt.index - result).total_seconds().max() <= 1
 
 
 def test_convert_datetime_index_ad(dataframe_dt):
@@ -133,6 +149,10 @@ def test_convert_datetime_index_ad(dataframe_dt):
     expected = np.array([2018.99657769, 2019.99657769, 2020.99931554, 2021.99657769, 2022.99657769])
     assert np.allclose(time.values, expected, rtol=1e-05, atol=1e-08)
 
+    # check we can round-trip
+    result = tsbase.time_to_datetime(time.values, 0, 0, 'prograde')
+    assert np.abs(dataframe_dt.index - result).total_seconds().max() <= 1
+
 
 def test_convert_datetime_index_nondt_index(dataframe):
     time_unit = 'yr'
@@ -143,4 +163,3 @@ def test_convert_datetime_index_nondt_index(dataframe):
             time_unit, 
             time_name=time_name,
             )
-


### PR DESCRIPTION
As discussed on Slack, let's use UDUNITS in seconds_per_year

If users have a calendar other than Gregorian, then conversion needs to happen before they use pyleoclim