### PR TITLE
Update environment, use new env in ci

### DIFF
--- a/.github/workflows/testdev.yml
+++ b/.github/workflows/testdev.yml
@@ -23,7 +23,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: pyleo
-        environment-file: environment.yml
+        environment-file: environment_dev.yml
         python-version: "3.10"
         auto-activate-base: false
     

--- a/.github/workflows/testmaster.yml
+++ b/.github/workflows/testmaster.yml
@@ -23,7 +23,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: pyleo
-        environment-file: environment.yml
+        environment-file: environment_dev.yml
         python-version: "3.10"
         auto-activate-base: false
     

--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,5 @@
+# This environment is used for JupyterHub
+
 name: pyleo
 channels:
   - conda-forge

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -1,0 +1,31 @@
+# Development environment. This environment includes all the required 
+# packages for this repo including running the test suite.
+name: pyleo
+channels:
+  - LinkedEarth 
+  - conda-forge
+  - default
+dependencies:
+  - python>=3.8
+  - cartopy
+  - matplotlib
+  - nitime
+  - numba
+  - numpy
+  - pathos
+  - pip
+  - pytest
+  - pyyaml
+  - requests
+  - scikit-learn
+  - scipy
+  - seaborn
+  - statsmodels
+  - tabulate
+  - tqdm
+  - wget
+  - pip:
+    - pyhht
+    - '-e .'
+    - "--pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple"
+    - pandas>=1.9


### PR DESCRIPTION
While I was working on other things, I did a little testing of the environment on the side. I know that the `environment.yml` has a specific usage outside of this package so I've created a new env (`environment.yml`). 

This contains all the required packages to run pyleoclim (as found by `depfinder`. One question I had was [this LiPD package](https://github.com/nickmckay/LiPD-utilities), but since it couldn't be installed into an environment, I suspect its not being used. 

I've also added this environment to CI since it explicitly contains all requirements. If we had 100% test coverage, the env we currently use in CI would not be sufficient. 

While I was adding it to CI, I realized that because the github action wasn't installing the checked out branch and was instead relying on the environment file, I think we've just been running tests on the Development branch, not the PRs 😵 This fixes that. 