### PR TITLE
Resample: use year-start as rule

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -4221,11 +4221,11 @@ class Series:
 
         This is a convenience method: doing
 
-            ser.resample('Y').mean()
+            ser.resample('AS').mean()
 
         will do the same thing as
 
-            ser.pandas_method(lambda x: x.resample('Y').mean())
+            ser.pandas_method(lambda x: x.resample('AS').mean())
         
         but will also accept some extra resampling rules, such as `'Ga'` (see below).
 
@@ -4281,7 +4281,7 @@ class Series:
             md['label'] = md['label'] + ' (' + rule + ' resampling)'
         
         ser = self.to_pandas()
-        return SeriesResampler(f'{multiplier}Y', ser, md, kwargs)
+        return SeriesResampler(f'{multiplier}AS', ser, md, kwargs)
 
 
 class SeriesResampler:


### PR DESCRIPTION
Currently, the `resample` results look a bit odd, in that the labels are always from the year-end:
```python
In [1]: import numpy as np
   ...: ser_index = pd.DatetimeIndex([
   ...:     np.datetime64('0000-01-01', 's'),
   ...:     np.datetime64('2000-01-01', 's'),
   ...: ])
   ...: ser = pd.Series(range(2), index=ser_index)
   ...: ts = pyleo.Series.from_pandas(ser, metadata={'time_unit': 'years CE', 'time_name': 'datetime'})

In [2]: ts.resample('1ka').mean()
Out[2]: {'log': ()}

None
datetime [years CE]
0.999337       0.0
1000.998793    NaN
2001.000986    1.0
Name: value, dtype: float64

In [3]: ts.resample('1ka').mean().datetime_index
Out[3]: DatetimeIndex(['0-12-31', '1000-12-31', '2000-12-31'], dtype='datetime64[s]', name='datetime', freq=None)
```

This is because we're using multiples of `'Y'` as the resample rule, which means "year end" - https://pandas.pydata.org/docs/dev/user_guide/timeseries.html#dateoffset-objects

My bad here, I should've used `'AS'` the first time. I think this make it align more with user expectations anyway.

The above example would look like this:
```python
In [1]: 
   ...: import numpy as np
   ...: ser_index = pd.DatetimeIndex([
   ...:     np.datetime64('0000-01-01', 's'),
   ...:     np.datetime64('2000-01-01', 's'),
   ...: ])
   ...: ser = pd.Series(range(2), index=ser_index)
   ...: ts = pyleo.Series.from_pandas(ser, metadata={'time_unit': 'years CE', 'time_name': 'datetime'})

In [2]: ts.resample('1ka').mean()
Out[2]: {'log': ()}

None
datetime [years CE]
0.000000       0.0
1000.002194    NaN
2000.001649    1.0
Name: value, dtype: float64

In [3]: ts.resample('1ka').mean().datetime_index
Out[3]: DatetimeIndex(['0-01-01', '1000-01-01', '2000-01-01'], dtype='datetime64[s]', name='datetime', freq=None)
```

There is still some rounding error in the `years CE` representation, due to using an approximation for the number of seconds in the year:

https://github.com/LinkedEarth/Pyleoclim_util/blob/0da854c3997cb762ddcc68074666e184c99ede81/pyleoclim/utils/tsbase.py#L24-L25

I've also added a test for `resample.interpolate`