### PR TITLE
Allow for non-pyleo rules in resample

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -4259,6 +4259,11 @@ class Series:
         search = re.search(r'(\d*)([a-zA-Z]+)', rule)
         if search is None:
             raise ValueError(f"Invalid rule provided, got: {rule}")
+
+        md = self.metadata
+        if md['label'] is not None:
+            md['label'] = md['label'] + ' (' + rule + ' resampling)'
+
         multiplier = search.group(1)
         if multiplier == '':
             multiplier = 1
@@ -4266,22 +4271,16 @@ class Series:
             multiplier = int(multiplier)
         unit = search.group(2)
         if unit.lower() in tsbase.MATCH_A:
-            pass
+            rule = f'{multiplier}AS'
         elif unit.lower() in tsbase.MATCH_KA:
-            multiplier *= 1_000
+            rule = f'{1_000*multiplier}AS'
         elif unit.lower() in tsbase.MATCH_MA:
-            multiplier *= 1_000_000
+            rule = f'{1_000_000*multiplier}AS'
         elif unit.lower() in tsbase.MATCH_GA:
-            multiplier *= 1_000_000_000
-        else:
-            raise ValueError(f'Invalid unit provided, got: {unit}')
-            
-        md = self.metadata
-        if md['label'] is not None:
-            md['label'] = md['label'] + ' (' + rule + ' resampling)'
+            rule = f'{1_000_000_000*multiplier}AS'
         
         ser = self.to_pandas()
-        return SeriesResampler(f'{multiplier}AS', ser, md, kwargs)
+        return SeriesResampler(rule, ser, md, kwargs)
 
 
 class SeriesResampler:

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -171,7 +171,6 @@ class Series:
         if dropna == True:
             value, time = tsbase.dropna(value, time, verbose=verbose)
             self.log += ({nlog+1: 'dropna', 'applied': dropna, 'verbose': verbose},)
-            nlog +=1
         elif dropna == False:
             pass
         else:
@@ -202,7 +201,7 @@ class Series:
             if sort_ts in ['ascending', 'descending']:
                 value, time = tsbase.sort_ts(value, time, verbose=verbose, 
                                              ascending = sort_ts == 'ascending')
-                self.log += ({nlog+1: 'sort_ts', 'direction': sort_ts},)
+                self.log += ({len(self.log)+1: 'sort_ts', 'direction': sort_ts},)
             else:
                 print(f"Unknown sorting option {sort_ts}; no sorting applied")
          
@@ -4300,8 +4299,8 @@ class SeriesResampler:
         self.rule = rule
         self.series = series
         self.metadata = metadata
-        self.kwargs = kwargs
         self.keep_log = keep_log
+        self.kwargs = kwargs
     
     def __getattr__(self, attr):
         attr = getattr(self.series.resample(self.rule,  **self.kwargs), attr)

--- a/pyleoclim/tests/conftest.py
+++ b/pyleoclim/tests/conftest.py
@@ -31,8 +31,8 @@ def metadata():
         'archiveType': 'Instrumental',
         'importedFrom': None,
         'log': (
-                {1: 'dropna', 'applied': True, 'verbose': True},
-                {2: 'sort_ts', 'direction': 'ascending'}
+                {0: 'dropna', 'applied': True, 'verbose': True},
+                {1: 'sort_ts', 'direction': 'ascending'}
             )
     }
 

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -1179,10 +1179,10 @@ class TestResample:
     def test_resample_invalid(self, dataframe_dt, metadata):
         ser = dataframe_dt.loc[:, 0]
         ts = pyleo.Series.from_pandas(ser, metadata)
-        with pytest.raises(ValueError, match='Invalid unit provided, got: foo'):
-            ts.resample('foo')
+        with pytest.raises(ValueError, match='Invalid frequency: foo'):
+            ts.resample('foo').sum()
         with pytest.raises(ValueError, match='Invalid rule provided, got: 412'):
-            ts.resample('412')
+            ts.resample('412').sum()
     
 
     def test_resample_interpolate(self, metadata):
@@ -1203,6 +1203,17 @@ class TestResample:
         )
         expected_ser = pd.Series([0, 0.5, 1], name='SOI', index=expected_idx)
         pd.testing.assert_series_equal(result_ser, expected_ser)
+
+
+    def test_resample_non_pyleo_unit(self):
+        ts1 = pyleo.Series(time=np.array([1, 1.1, 1.2]), value=np.array([8, 3, 5]), time_unit='yr CE')
+        result= ts1.resample('MS').sum()
+        expected = pyleo.Series(
+            time=np.array([0.9171996 , 1.00207479, 1.08694998, 1.16361144]),
+            value=np.array([8., 0., 3., 5.]),
+            time_unit='yr CE',
+        )
+        assert result.equals(expected) == (True, True)
 
 
 class TestUISeriesEquals():

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -1122,8 +1122,8 @@ class TestResample:
             'archiveType': 'Instrumental',
             'importedFrom': None,
             'log': (
-                    {1: 'dropna', 'applied': True, 'verbose': True},
-                    {2: 'sort_ts', 'direction': 'ascending'}
+                    {0: 'dropna', 'applied': True, 'verbose': True},
+                    {1: 'sort_ts', 'direction': 'ascending'}
                 )
         }
         pd.testing.assert_series_equal(result_ser, expected_ser)
@@ -1166,8 +1166,8 @@ class TestResample:
             'archiveType': 'Instrumental',
             'importedFrom': None,
             'log': (
-                    {1: 'dropna', 'applied': True, 'verbose': True},
-                    {2: 'sort_ts', 'direction': 'ascending'}
+                    {0: 'dropna', 'applied': True, 'verbose': True},
+                    {1: 'sort_ts', 'direction': 'ascending'}
                 )
         }
         # check indexes match to within 10 seconds
@@ -1229,7 +1229,19 @@ class TestResample:
             time_unit='yr CE',
         )
         assert result.equals(expected) == (True, True)
-
+        
+    def test_resample_log(self, metadata):
+        ser_index = pd.DatetimeIndex([
+            np.datetime64('0000-01-01', 's'),
+            np.datetime64('2000-01-01', 's'),
+        ])
+        ser = pd.Series(range(2), index=ser_index)
+        ts = pyleo.Series.from_pandas(ser, metadata)
+        result_ser = ts.resample('ka',keep_log=True).interpolate()
+        expected_log = ({0: 'dropna', 'applied': True, 'verbose': True},
+                        {1: 'sort_ts', 'direction': 'ascending'},
+                        {2: 'resample', 'rule': '1000AS'})
+        assert result_ser.log == expected_log
 
 class TestUISeriesEquals():
     ''' Test for equals() method '''


### PR DESCRIPTION
As requested on Slack

> to be specific: I’d like resample() to accept both the usual frequency string semantics AND the ones defined in Pyleoclim (MATCH_A, MATCH_KA, MATCH_MA and MATCH_GA). It seems that it should be possible since there is no conflict in terminology between the two systems, AFAICT, but I don’t know what would need to happen under the hood.