### PR TITLE
added segment number to labels

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -2369,9 +2369,13 @@ class Series:
         if len(seg_y)>1:
             s_list=[]
             for idx,s in enumerate(seg_y):
+                if self.label is not None: 
+                    s_lbl =  self.label + ' segment ' + str(idx+1)  
+                else:
+                    s_lbl =  'segment ' + str(idx+1)  
                 s_tmp=Series(time=seg_t[idx],value=s,time_name=self.time_name,
                               time_unit=self.time_unit, value_name=self.value_name,
-                              value_unit=self.value_unit,label=self.label)
+                              value_unit=self.value_unit,label=s_lbl)
                 s_list.append(s_tmp)
             res=MultipleSeries(series_list=s_list)
         elif len(seg_y)==1:
@@ -2379,6 +2383,7 @@ class Series:
         else:
             raise ValueError('No timeseries detected')
         return res
+    
     
     def sel(self, value=None, time=None, tolerance=0):
         """

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -430,6 +430,17 @@ class TestUiSeriesSegment:
         ts_seg = ts.segment()
 
         assert type(ts_seg) == type(ts)
+        
+    def test_segment_t2(self):
+        '''Test that in the case of segmentation, segment returns a Multiple Series object'''
+        t = (1,2,3000)
+        v = (1,2,3)
+
+        ts = pyleo.Series(time = t, value = v, label = 'series')
+
+        ts_seg = ts.segment()
+
+        assert ts_seg.series_list[0].label == 'series segment 1'
 
 class TestUiSeriesSlice:
     '''Test for Series.slice()


### PR DESCRIPTION
Previously,`ts.segment()` would export a MS object whose constituent series all had the same label, making it impossible for methods like `MS.remove()` to work properly. This PR adds a number to each segment so they can be differentiated. 