### PR TITLE
Stripe fix

### DIFF
--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -2024,8 +2024,9 @@ class MultipleSeries:
         else:
             return ax
         
-    def stripes(self, ref_period=None, figsize=None, savefig_settings=None,  time_unit=None,
-                LIM = 2.8, thickness=1.0, labels='auto',  label_color = 'gray',
+    def stripes(self, cmap = 'RdBu_r', sat=0.9, ref_period=None,
+                figsize=None, savefig_settings=None,  time_unit=None,
+                labels='auto',  label_color = 'gray', show_xaxis=False,
                 common_time_kwargs=None, xlim=None, font_scale=0.8, x_offset = 0.05):
         '''
         Represents a MultipleSeries object as a quilt of Ed Hawkins' "stripes" patterns
@@ -2039,21 +2040,23 @@ class MultipleSeries:
 
         Parameters
         ----------
-
+        cmap: str
+            seaborn-friendly colormap name (https://seaborn.pydata.org/tutorial/color_palettes.html#sequential-color-palettes)    
+            
         ref_period : TYPE, optional
             dates of the reference period, in the form "(first, last)".
             The default is None, which will pick the beginning and end of the common time axis.
         
-        LIM : float
-            scaling factor for color saturation. default is 2.8. 
-            The higher the LIM, the more compressed the color range (milder hues)
-        
-        thickness : float, optional
-            vertical thickness of the stripe . The default is 1.0
-            
         figsize : list
+            a list of two integers indicating the figure size (in inches)
         
-            Size of the figure.
+        
+        sat : float > 0
+            Controls the saturation of the colormap normalization by scaling the vmin, vmax in https://matplotlib.org/stable/tutorials/colors/colormapnorms.html
+            default = 0.9
+            
+        show_xaxis : bool
+            flag indicating whether or not the x-axis should be shown (default = False) 
             
         savefig_settings : dictionary
         
@@ -2188,19 +2191,21 @@ class MultipleSeries:
         fig, axs = plt.subplots(n_ts, 1, sharex=True, figsize=figsize, layout = 'tight')
         ax = axs.flatten()
 
-        if xlim is None:
-            xlim = [time.min(), time.max()]
-
         for idx in range(n_ts-1):  # loop over series
-            ts = msc.series_list[idx].gaussianize()
-            ts.stripes(ref_period, LIM = LIM, label_color = label_color,
+            ts = msc.series_list[idx]
+            ts.stripes(ref_period, sat=sat, cmap= cmap,
+                       label_color = label_color,
                        ax=ax[idx], x_offset=x_offset) 
             
         # handle bottom plot
-        ts = msc.series_list[last].gaussianize()
-        ts.stripes(ref_period, LIM = LIM, label_color = label_color, 
-                   ax=ax[last], x_offset=x_offset, show_xaxis=True) 
-        ax[last].set_xlabel(time_label)
+        ts = msc.series_list[last]
+        ts.stripes(ref_period, sat=sat, cmap=cmap,
+                   label_color = label_color, show_xaxis=show_xaxis,
+                   ax=ax[last], x_offset=x_offset) 
+        
+        #ax[last].set_xlabel(time_label)
+        if xlim is None:
+            xlim = [time.min(), time.max()]
         ax[last].set_xlim(xlim)
 
         if 'fig' in locals():

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -2024,7 +2024,7 @@ class MultipleSeries:
         else:
             return ax
         
-    def stripes(self, cmap = 'RdBu_r', sat=0.9, ref_period=None,
+    def stripes(self, cmap = 'RdBu_r', sat=1.0, ref_period=None,
                 figsize=None, savefig_settings=None,  time_unit=None,
                 labels='auto',  label_color = 'gray', show_xaxis=False,
                 common_time_kwargs=None, xlim=None, font_scale=0.8, x_offset = 0.05):
@@ -2041,7 +2041,8 @@ class MultipleSeries:
         Parameters
         ----------
         cmap: str
-            seaborn-friendly colormap name (https://seaborn.pydata.org/tutorial/color_palettes.html#sequential-color-palettes)    
+            colormap name (https://matplotlib.org/stable/tutorials/colors/colormaps.html)
+            Default is 'RdBu_r'
             
         ref_period : TYPE, optional
             dates of the reference period, in the form "(first, last)".
@@ -2053,7 +2054,7 @@ class MultipleSeries:
         
         sat : float > 0
             Controls the saturation of the colormap normalization by scaling the vmin, vmax in https://matplotlib.org/stable/tutorials/colors/colormapnorms.html
-            default = 0.9
+            default = 1.0
             
         show_xaxis : bool
             flag indicating whether or not the x-axis should be shown (default = False) 
@@ -2129,12 +2130,11 @@ class MultipleSeries:
             :okexcept:
 
             import pyleoclim as pyleo
-            url = 'http://wiki.linked.earth/wiki/index.php/Special:WTLiPD?op=export&lipdid=MD982176.Stott.2004'
-            d = pyleo.Lipd(usr_path = url)
-            tslist = d.to_LipdSeriesList()
-            tslist = tslist[2:] # drop the first two series which only concerns age and depth
-            ms = pyleo.MultipleSeries(tslist)
-            @savefig md76_stripes.png
+            co2ts = pyleo.utils.load_dataset('AACO2')
+            lr04 = pyleo.utils.load_dataset('LR04')
+            edc = pyleo.utils.load_dataset('EDC-dD')
+            ms = lr04.flip() & edc & co2ts # create MS object
+            @savefig ms_stripes.png
             fig, ax = ms.stripes()
             pyleo.closefig(fig)
              
@@ -2147,16 +2147,14 @@ class MultipleSeries:
             :okwarning:
             :okexcept:
 
-            import pyleoclim as pyleo
-            url = 'http://wiki.linked.earth/wiki/index.php/Special:WTLiPD?op=export&lipdid=MD982176.Stott.2004'
-            d = pyleo.Lipd(usr_path = url)
-            tslist = d.to_LipdSeriesList()
-            tslist = tslist[2:] # drop the first two series which only concerns age and depth
-            ms = pyleo.MultipleSeries(tslist)
-            @savefig md76_stripes2.png
-            fig, ax = ms.stripes(common_time_kwargs={'step': 0.5}, x_offset = 200, 
-                                 LIM=4, figsize=[8,3])
-            pyleo.closefig(fig)     
+             import pyleoclim as pyleo
+             co2ts = pyleo.utils.load_dataset('AACO2')
+             lr04 = pyleo.utils.load_dataset('LR04')
+             edc = pyleo.utils.load_dataset('EDC-dD')
+             ms = lr04.flip() & edc & co2ts # create MS object
+             @savefig ms_stripes2.png
+             fig, ax = ms.stripes(figsize=(8,2.5),show_xaxis=True, sat = 0.8)
+             pyleo.closefig(fig)
             
         '''
         current_style = deepcopy(mpl.rcParams)
@@ -2203,10 +2201,11 @@ class MultipleSeries:
                    label_color = label_color, show_xaxis=show_xaxis,
                    ax=ax[last], x_offset=x_offset) 
         
-        #ax[last].set_xlabel(time_label)
         if xlim is None:
             xlim = [time.min(), time.max()]
         ax[last].set_xlim(xlim)
+        
+        fig.tight_layout()
 
         if 'fig' in locals():
             if 'path' in savefig_settings:

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -2162,6 +2162,10 @@ class MultipleSeries:
         savefig_settings = {} if savefig_settings is None else savefig_settings.copy()
         common_time_kwargs = {} if common_time_kwargs is None else common_time_kwargs.copy()
         
+        if len(self.series_list)>20:
+            warnings.warn("You are trying to plot over 20 series; results will be hard to see",
+                          UserWarning, stacklevel=2)
+        
         # deal with time units
         self = self.convert_time_unit(time_unit=time_unit)
 

--- a/pyleoclim/core/psds.py
+++ b/pyleoclim/core/psds.py
@@ -324,7 +324,7 @@ class PSD:
         elif method == 'ar1asym':
             std = self.timeseries.stats()['std'] # assess standard deviation 
             if np.abs(std-1) > 0.1: 
-                warnings.warn("Asymptoics are only defined for a standard deviation of unity. Please apply to a standardized series only")
+                warnings.warn("Asymptotics are only defined for a standard deviation of unity. Please apply to a standardized series only")
             
             new=self.copy()
 

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -1047,12 +1047,15 @@ class Series:
         
         >>> gmst = pyleo.utils.load_dataset('HadCRUT5')
         >>> fig, ax = gmst.stripes(ref_period=(1971,2000))
+        
+        For inclusion in a Pottery Barn catalog, dial down saturation:
+        >>>  fig, ax = gmst.stripes(ref_period=(1971,2000), sat = 0.6)
 
         To change the colormap:
         
         >>> fig, ax = gmst.stripes(ref_period=(1971,2000), cmap='Spectral_r')
         >>> fig, ax = gmst.stripes(ref_period=(1971,2000), cmap='magma_r')
-
+        
         If you wanted to show the time axis: 
 
         >>> fig, ax = gmst.stripes(ref_period=(1971,2000), show_xaxis=True)
@@ -1071,7 +1074,6 @@ class Series:
         if sat <= 0:
             raise ValueError('sat must be a strictly positive number, ideally close to unity.')
          
-        #LIMs = self.value.std()*LIM
         # Ed Hawkins says: Currently I use HadCRUT5 with a 1971-2000 baseline
         # and a colour scaling of +/- 0.75K (which is probably similar to LIM).
         # It should be relatively simple to duplicate the stripes exactly
@@ -1081,10 +1083,13 @@ class Series:
         ys = yc/np.abs(yc).max()
         vmax = 1.0/sat
         
+        time_label, _ = self.make_labels()
+
         res = plotting.stripes_xy(x=self.time, y=ys, cmap=cmap, vmin=-vmax, vmax=vmax,
             top_label = top_label, bottom_label = bottom_label, label_color = label_color,
-            figsize=figsize, ax=ax,  xlim=xlim, invert_xaxis=invert_xaxis,  label_size=label_size,
-            savefig_settings=savefig_settings, show_xaxis=show_xaxis, x_offset = x_offset,
+            figsize=figsize, ax=ax,  xlim=xlim, invert_xaxis=invert_xaxis,  
+            label_size=label_size, time_label = time_label, x_offset = x_offset,
+            savefig_settings=savefig_settings, show_xaxis=show_xaxis, 
         )
 
         return res

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -965,7 +965,7 @@ class Series:
         return res
 
     def stripes(self, figsize=[8, 1], cmap = 'RdBu_r', ref_period=None,  
-                sat=0.9, top_label=None, bottom_label=None, 
+                sat=1.0, top_label=None, bottom_label=None, 
                 label_color = 'gray', label_size = None, xlim=None, 
                 xlabel=None, savefig_settings=None, ax=None, invert_xaxis=False,
                 show_xaxis=False, x_offset = 0.03):
@@ -982,7 +982,7 @@ class Series:
             a list of two integers indicating the figure size (in inches)
         
         cmap: str
-            seaborn-friendly colormap name (https://seaborn.pydata.org/tutorial/color_palettes.html#sequential-color-palettes)    
+            colormap name (https://matplotlib.org/stable/tutorials/colors/colormaps.html)
             
         sat : float > 0
             Controls the saturation of the colormap normalization by scaling the vmin, vmax in https://matplotlib.org/stable/tutorials/colors/colormapnorms.html
@@ -1034,9 +1034,7 @@ class Series:
 
         See also
         --------
-
         pyleoclim.utils.plotting.stripes : stripes representation of a timeseries
-
         pyleoclim.utils.plotting.savefig : saving a figure in Pyleoclim
         
         
@@ -1044,20 +1042,17 @@ class Series:
         --------
 
         Plot the HadCRUT5 Global Mean Surface Temperature
-        
         >>> gmst = pyleo.utils.load_dataset('HadCRUT5')
         >>> fig, ax = gmst.stripes(ref_period=(1971,2000))
         
-        For inclusion in a Pottery Barn catalog, dial down saturation:
-        >>>  fig, ax = gmst.stripes(ref_period=(1971,2000), sat = 0.6)
+        For a more pastel tone, dial down saturation:
+        >>>  fig, ax = gmst.stripes(ref_period=(1971,2000), sat = 0.8)
 
-        To change the colormap:
-        
+        To change the colormap:    
         >>> fig, ax = gmst.stripes(ref_period=(1971,2000), cmap='Spectral_r')
         >>> fig, ax = gmst.stripes(ref_period=(1971,2000), cmap='magma_r')
         
-        If you wanted to show the time axis: 
-
+        To show the time axis: 
         >>> fig, ax = gmst.stripes(ref_period=(1971,2000), show_xaxis=True)
 
         '''
@@ -1080,15 +1075,14 @@ class Series:
         
         # center and normalize values for proper display
         yc =  self.center(timespan=ref_period).value
-        ys = yc/np.abs(yc).max()
-        vmax = 1.0/sat
+        vmax = np.abs(yc).max()/sat
         
         time_label, _ = self.make_labels()
 
-        res = plotting.stripes_xy(x=self.time, y=ys, cmap=cmap, vmin=-vmax, vmax=vmax,
+        res = plotting.stripes_xy(x=self.time, y=yc, cmap=cmap, vmin=-vmax, vmax=vmax,
             top_label = top_label, bottom_label = bottom_label, label_color = label_color,
             figsize=figsize, ax=ax,  xlim=xlim, invert_xaxis=invert_xaxis,  
-            label_size=label_size, time_label = time_label, x_offset = x_offset,
+            label_size=label_size, xlabel = time_label, x_offset = x_offset,
             savefig_settings=savefig_settings, show_xaxis=show_xaxis, 
         )
 

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -968,7 +968,7 @@ class Series:
                 sat=0.9, top_label=None, bottom_label=None, 
                 label_color = 'gray', label_size = None, xlim=None, 
                 xlabel=None, savefig_settings=None, ax=None, invert_xaxis=False,
-                show_xaxis=False, x_offset = 0.05):
+                show_xaxis=False, x_offset = 0.03):
         '''Represents the Series as an Ed Hawkins "stripes" pattern
 
         Credit: https://matplotlib.org/matplotblog/posts/warming-stripes/
@@ -1053,11 +1053,10 @@ class Series:
         >>> fig, ax = gmst.stripes(ref_period=(1971,2000), cmap='Spectral_r')
         >>> fig, ax = gmst.stripes(ref_period=(1971,2000), cmap='magma_r')
 
-        If you wanted to show the time axis: [REPAIR]
+        If you wanted to show the time axis: 
 
-        >>> fig, ax = gmst.stripes(ref_period=(1971,2000), show_xaxis=True, figsize=[8, 1.2])
+        >>> fig, ax = gmst.stripes(ref_period=(1971,2000), show_xaxis=True)
 
-        Note that we had to increase the figure height to make space for the extra text.
         '''
 
         if top_label is None:

--- a/pyleoclim/tests/test_core_MultipleSeries.py
+++ b/pyleoclim/tests/test_core_MultipleSeries.py
@@ -127,6 +127,7 @@ class TestMultipleSeriesPlot:
         assert_allclose(t_1, x_plot_1)
         assert_allclose(v_0, y_plot_0)
         assert_allclose(v_1, y_plot_1)
+        pyleo.closefig(fig)
 
 class TestMultipleSeriesStripes:
     '''Test for MultipleSeries.stripes()
@@ -140,17 +141,14 @@ class TestMultipleSeriesStripes:
         t_1, v_1 = gen_normal()
 
         #Create series objects
-        ts_0 = pyleo.Series(time = t_0, value = v_0)
-        ts_1 = pyleo.Series(time = t_1, value = v_1)
-
-        #Create a list of series objects
-        serieslist = [ts_0, ts_1]
+        ts_0 = pyleo.Series(time = t_0, value = v_0, label='series 1')
+        ts_1 = pyleo.Series(time = t_1, value = v_1, label='series 2')
 
         #Turn this list into a multiple series object
-        ts_M = pyleo.MultipleSeries(serieslist)
+        ts_M = ts_0 &  ts_1
 
-        fig, ax = ts_M.stripes(LIM=4, x_offset=2, label_color = 'red')
-
+        fig, ax = ts_M.stripes(sat=0.9, label_color = 'red', cmap='cividis_r')
+        pyleo.closefig(fig)
 
 class TestMultipleSeriesStandardize:
     '''Test for MultipleSeries.standardize()

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -1037,22 +1037,17 @@ class TestUiSeriesPlot:
 
         x_plot = line.get_xdata()
         y_plot = line.get_ydata()
-
-
         pyleo.closefig(fig)
 
 class TestUiSeriesStripes:
-    '''Test for Series.stripes()
-
-    Series.stripes outputs a matplotlib figure and axis object, so we will compare the time axis
-    of the axis object to the time array.'''
-
-    def test_stripes(self):
+    '''Test for Series.stripes()'''
+    @pytest.mark.parametrize('show_xaxis', [True, False])
+    def test_stripes(self, show_xaxis):
 
         ts = gen_normal()
 
-        fig, ax = ts.stripes(ref_period=[61,90],x_offset=2)
-
+        fig, ax = ts.stripes(ref_period=[61,90], show_xaxis=show_xaxis)
+        assert ax.xaxis.get_ticklabels() != []
         pyleo.closefig(fig)
 
 

--- a/pyleoclim/utils/plotting.py
+++ b/pyleoclim/utils/plotting.py
@@ -300,11 +300,12 @@ def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
                vmin=None, vmax=None, xlabel=None, ylabel=None,
                title=None, xlim=None, savefig_settings=None, label_color = None,
                x_offset = 0.05, label_size = None, show_xaxis = False,
-               invert_xaxis=False, top_label = None, bottom_label = None): 
+               time_label = 'time', invert_xaxis=False, 
+               top_label = None, bottom_label = None): 
     '''
     Represent y = f(x) as an Ed Hawkins "warming stripes" pattern
     
-    Credit: https://matplotlib.org/matplotblog/posts/warming-stripes/
+    Credit: https://esmvalgroup.github.io/ESMValTool_Tutorial/files/warming_stripes.py
     
     Parameters
     ----------
@@ -334,7 +335,8 @@ def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
         value controlling the horizontal offset between stripes and labels (default = 0.05)
     show_xaxis : bool
         flag indicating whether or not the x-axis should be shown (default = False)
-    
+    time_label : str
+        string for the time axis
     savefig_settings : dict
         the dictionary of arguments for plt.savefig(); some notes below:
         - "path" must be specified; it can be any existing or non-existing path,
@@ -361,30 +363,25 @@ def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
       
     if label_size is None:
         label_size = mpl.rcParams['axes.labelsize']
-    # form dataframe to pass to seaborn
-    df = pd.DataFrame(y[np.newaxis,:]); df.columns = x
-    
+
+    ones = np.array([0, 1])
+    ax.pcolormesh(x, ones, np.vstack([y, y]), cmap=cmap, 
+                  vmin=vmin, vmax=vmax, shading='auto')
+    ax.get_yaxis().set_visible(False)
+    ax.get_xaxis().set_visible(show_xaxis)
+
     if show_xaxis:
-        ax.plot(x,(x-x.min())/x.ptp()) # create dummy plot to extract xticks/labels
+        if time_label is not None:
+            ax.set_xlabel(time_label)
     
-    xpos = [df.columns.get_loc(c) for c in ax.get_xticks() if c in df]
-    xlabs = x[xpos].astype(int)
-    # draw the heat map
-    ax = sns.heatmap(data=df, ax =ax,
-                          cmap=cmap, cbar=False,
-                          vmin=vmin, vmax=vmax, center=0.,
-                          xticklabels=False, yticklabels=False,
-                          )
-    # adjust ticks (empty or not)
-    ax.set_xticks(xpos)
-    ax.set_xticklabels(xlabs)
-    
+
     # parameters for label position
     thickness = ax.get_ybound()[1]
-    xmax = ax.get_xbound()[1]*(1+x_offset)
-    ax.text(xmax, 0.85*thickness, top_label, color=label_color, 
+    xmax = ax.get_xbound()[1]*(1+x_offset/10)
+    #xmax = x.max()*0.8*(1+x_offset)
+    ax.text(xmax, 0.4*thickness, top_label, color=label_color, 
             fontsize=label_size, fontweight = 'bold')
-    ax.text(xmax, 0.30*thickness, bottom_label, color=label_color,
+    ax.text(xmax, -0.1*thickness, bottom_label, color=label_color,
             fontsize=label_size)
 
     if xlabel is not None:

--- a/pyleoclim/utils/plotting.py
+++ b/pyleoclim/utils/plotting.py
@@ -299,7 +299,7 @@ def plot_xy(x, y, figsize=None, xlabel=None, ylabel=None, title=None,
 def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
                vmin=None, vmax=None, xlabel=None, ylabel=None,
                title=None, xlim=None, savefig_settings=None, label_color = None,
-               x_offset = None, label_size = None, show_xaxis = False,
+               x_offset = 0.05, label_size = None, show_xaxis = False,
                invert_xaxis=False, top_label = None, bottom_label = None): 
     '''
     Represent y = f(x) as an Ed Hawkins "warming stripes" pattern
@@ -323,9 +323,9 @@ def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
     vmax: float 
         upper bound for colormap normalization    
     top_label : str
-        the "title" label for the stripe
+        the "title" label for the stripe. Set to '' if no label is wanted
     bottom_label : str
-        the "ylabel" explaining which variable is being plotted
+        the "ylabel" explaining which variable is being plotted. Set to '' if no label is wanted
     label_size : int
         size of the text in labels (in points). Default is the Matplotlib 'axes.labelsize'] rcParams
     xlim : list
@@ -361,61 +361,31 @@ def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
       
     if label_size is None:
         label_size = mpl.rcParams['axes.labelsize']
-        
-
-    # ax.get_yaxis().set_visible(False) # remove parasitic lines and labels
+    # form dataframe to pass to seaborn
+    df = pd.DataFrame(y[np.newaxis,:]); df.columns = x
     
+    if show_xaxis:
+        ax.plot(x,(x-x.min())/x.ptp()) # create dummy plot to extract xticks/labels
     
-    
-   
-    
-    # # Reference period for the center of the color scale    
-    # reference = y[ref_period[0]:ref_period[1]].mean()
-    
-    # # colormap: the 8 more saturated colors from the 9 blues / 9 reds
-    # cmap = ListedColormap([
-    #     '#08306b', '#08519c', '#2171b5', '#4292c6',
-    #     '#6baed6', '#9ecae1', '#c6dbef', '#deebf7',
-    #     '#fee0d2', '#fcbba1', '#fc9272', '#fb6a4a',
-    #     '#ef3b2c', '#cb181d', '#a50f15', '#67000d',
-    # ])
-    
-    # col = PatchCollection([
-    #     Rectangle((yl, 0), 1, 1)
-    #     for yl in range(int(xmin), int(xmax))
-    #     ])
-
-    # # set data, colormap and color limits
-    # col.set_array(y)
-    # col.set_cmap(cmap)
-    # col.set_clim(reference - LIM, reference + LIM)
-    # ax.add_collection(col)
-    # # adjust axes
-    # ax.set_ylim(0, thickness)
-    # ax.set_xlim(xmin, xmax);
-    
-    
-    sns.heatmap(data=y[np.newaxis,:], ax =ax,
+    xpos = [df.columns.get_loc(c) for c in ax.get_xticks() if c in df]
+    xlabs = x[xpos].astype(int)
+    # draw the heat map
+    ax = sns.heatmap(data=df, ax =ax,
                           cmap=cmap, cbar=False,
                           vmin=vmin, vmax=vmax, center=0.,
                           xticklabels=False, yticklabels=False,
                           )
-    if show_xaxis:
-        tx = ax.twiny()
-        tx.plot(x*np.nan)
-        #ax.get_xaxis().set_visible(show_xaxis) # apply show_xasis
+    # adjust ticks (empty or not)
+    ax.set_xticks(xpos)
+    ax.set_xticklabels(xlabs)
     
     # parameters for label position
     thickness = ax.get_ybound()[1]
-    
     xmax = ax.get_xbound()[1]*(1+x_offset)
-
     ax.text(xmax, 0.85*thickness, top_label, color=label_color, 
             fontsize=label_size, fontweight = 'bold')
     ax.text(xmax, 0.30*thickness, bottom_label, color=label_color,
             fontsize=label_size)
-    
-
 
     if xlabel is not None:
         ax.set_xlabel(xlabel)

--- a/pyleoclim/utils/plotting.py
+++ b/pyleoclim/utils/plotting.py
@@ -11,9 +11,11 @@ import matplotlib.pyplot as plt
 import pathlib
 import matplotlib as mpl
 import numpy as np
+import pandas as pd
 from matplotlib.patches import Rectangle
 from matplotlib.collections import PatchCollection
 from matplotlib.colors import ListedColormap
+import seaborn as sns
 
 
 def scatter_xy(x,y,c=None, figsize=None, xlabel=None, ylabel=None, title=None, 
@@ -294,10 +296,11 @@ def plot_xy(x, y, figsize=None, xlabel=None, ylabel=None, title=None,
     else:
         return ax
     
-def stripes_xy(x, y, ref_period, thickness = 1.0, LIM = 0.75, figsize=None, xlabel=None, 
-               ylabel=None, title=None, xlim=None, savefig_settings=None, ax=None, 
-               x_offset = 0.05, label_size = None, show_xaxis = False,
-               invert_xaxis=False, top_label = None, bottom_label = None, label_color = None): 
+def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
+               vmin=None, vmax=None, xlabel=None, ylabel=None,
+               title=None, xlim=None, savefig_settings=None, label_color = None,
+               x_offset = None, label_size = None, show_xaxis = False,
+               invert_xaxis=False, top_label = None, bottom_label = None): 
     '''
     Represent y = f(x) as an Ed Hawkins "warming stripes" pattern
     
@@ -308,15 +311,17 @@ def stripes_xy(x, y, ref_period, thickness = 1.0, LIM = 0.75, figsize=None, xlab
     x : array
         Independent variable
     y : array
-        Dependent variable
-    ref_period : 2-tuple or 2-vector
-        indices of the reference period, in the form "(first, last)"
-    thickness : float, optional
-        vertical thickness of the stripe . The default is 1.0     
-    LIM : float, optional 
-        size of the y-value range (default: 0.7) 
+        Dependent variable (asumees centered and normalized to unit standard deviation)
+    cmap: str
+        seaborn-friendly colormap 
     figsize : list
         a list of two integers indicating the figure size
+    ax : pyplot.axis
+        the pyplot.axis object, default is None
+    vmin: float 
+        lower bound for colormap normalization
+    vmax: float 
+        upper bound for colormap normalization    
     top_label : str
         the "title" label for the stripe
     bottom_label : str
@@ -325,12 +330,11 @@ def stripes_xy(x, y, ref_period, thickness = 1.0, LIM = 0.75, figsize=None, xlab
         size of the text in labels (in points). Default is the Matplotlib 'axes.labelsize'] rcParams
     xlim : list
         set the limits of the x axis
-    x_offset : float
+    x_offset : float (0-1)
         value controlling the horizontal offset between stripes and labels (default = 0.05)
     show_xaxis : bool
         flag indicating whether or not the x-axis should be shown (default = False)
-    ax : pyplot.axis
-        the pyplot.axis object
+    
     savefig_settings : dict
         the dictionary of arguments for plt.savefig(); some notes below:
         - "path" must be specified; it can be any existing or non-existing path,
@@ -338,10 +342,15 @@ def stripes_xy(x, y, ref_period, thickness = 1.0, LIM = 0.75, figsize=None, xlab
         - "format" can be one of {"pdf", "eps", "png", "ps"}
     invert_xaxis : bool, optional
         if True, the x-axis of the plot will be inverted
+        
+    See Also
+    --------
+    https://seaborn.pydata.org/tutorial/color_palettes.html#sequential-color-palettes
+    https://matplotlib.org/stable/tutorials/colors/colormapnorms.html
    
     Returns
     -------
-    ax, or fig, ax (if no axes were provided)
+    ax, or (fig, ax) if no axes were provided.
 
     '''
     # handle dict defaults
@@ -352,53 +361,61 @@ def stripes_xy(x, y, ref_period, thickness = 1.0, LIM = 0.75, figsize=None, xlab
       
     if label_size is None:
         label_size = mpl.rcParams['axes.labelsize']
-      
-    if thickness is None:
-        thickness = 5*label_size
         
-    ax.get_yaxis().set_visible(False) # remove parasitic lines and labels
-    ax.get_xaxis().set_visible(show_xaxis) # remove parasitic lines and labels
-    ax.spines[:].set_visible(False)
-    
-    dx = np.diff(x).mean()
-    xmin = x.min()
-    xmax = x.max() + dx # inclusive
-    
-    # Reference period for the center of the color scale    
-    reference = y[ref_period[0]:ref_period[1]].mean()
-    
-    # colormap: the 8 more saturated colors from the 9 blues / 9 reds
-    cmap = ListedColormap([
-        '#08306b', '#08519c', '#2171b5', '#4292c6',
-        '#6baed6', '#9ecae1', '#c6dbef', '#deebf7',
-        '#fee0d2', '#fcbba1', '#fc9272', '#fb6a4a',
-        '#ef3b2c', '#cb181d', '#a50f15', '#67000d',
-    ])
-    
-    col = PatchCollection([
-        Rectangle((yl, 0), 1, 1)
-        for yl in range(int(xmin), int(xmax))
-        ])
 
-    # set data, colormap and color limits
-    col.set_array(y)
-    col.set_cmap(cmap)
-    col.set_clim(reference - LIM, reference + LIM)
-    ax.add_collection(col)
-    # adjust axes
-    ax.set_ylim(0, thickness)
-    ax.set_xlim(xmin, xmax);
+    # ax.get_yaxis().set_visible(False) # remove parasitic lines and labels
     
-    # add label to the right 
-    #offset = y_offsets[column] / 72
-    #trans = mtransforms.ScaledTranslation(0, offset, fig.dpi_scale_trans)
-    #trans = ax.transData #+ trans
     
-    ypos = 0.4*thickness
-    ax.text(xmax+dx+x_offset, 0.6*thickness, top_label, color=label_color, 
+    
+   
+    
+    # # Reference period for the center of the color scale    
+    # reference = y[ref_period[0]:ref_period[1]].mean()
+    
+    # # colormap: the 8 more saturated colors from the 9 blues / 9 reds
+    # cmap = ListedColormap([
+    #     '#08306b', '#08519c', '#2171b5', '#4292c6',
+    #     '#6baed6', '#9ecae1', '#c6dbef', '#deebf7',
+    #     '#fee0d2', '#fcbba1', '#fc9272', '#fb6a4a',
+    #     '#ef3b2c', '#cb181d', '#a50f15', '#67000d',
+    # ])
+    
+    # col = PatchCollection([
+    #     Rectangle((yl, 0), 1, 1)
+    #     for yl in range(int(xmin), int(xmax))
+    #     ])
+
+    # # set data, colormap and color limits
+    # col.set_array(y)
+    # col.set_cmap(cmap)
+    # col.set_clim(reference - LIM, reference + LIM)
+    # ax.add_collection(col)
+    # # adjust axes
+    # ax.set_ylim(0, thickness)
+    # ax.set_xlim(xmin, xmax);
+    
+    
+    sns.heatmap(data=y[np.newaxis,:], ax =ax,
+                          cmap=cmap, cbar=False,
+                          vmin=vmin, vmax=vmax, center=0.,
+                          xticklabels=False, yticklabels=False,
+                          )
+    if show_xaxis:
+        tx = ax.twiny()
+        tx.plot(x*np.nan)
+        #ax.get_xaxis().set_visible(show_xaxis) # apply show_xasis
+    
+    # parameters for label position
+    thickness = ax.get_ybound()[1]
+    
+    xmax = ax.get_xbound()[1]*(1+x_offset)
+
+    ax.text(xmax, 0.85*thickness, top_label, color=label_color, 
             fontsize=label_size, fontweight = 'bold')
-    ax.text(xmax+dx+x_offset, 0.2*thickness, bottom_label, color=label_color,
+    ax.text(xmax, 0.30*thickness, bottom_label, color=label_color,
             fontsize=label_size)
+    
+
 
     if xlabel is not None:
         ax.set_xlabel(xlabel)
@@ -416,7 +433,7 @@ def stripes_xy(x, y, ref_period, thickness = 1.0, LIM = 0.75, figsize=None, xlab
         ax.invert_xaxis()       
 
     if 'fig' in locals():
-        fig.tight_layout()
+        #fig.tight_layout()
         if 'path' in savefig_settings:
             savefig(fig, settings=savefig_settings)
         return fig, ax

--- a/pyleoclim/utils/plotting.py
+++ b/pyleoclim/utils/plotting.py
@@ -300,11 +300,10 @@ def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
                vmin=None, vmax=None, xlabel=None, ylabel=None,
                title=None, xlim=None, savefig_settings=None, label_color = None,
                x_offset = 0.05, label_size = None, show_xaxis = False,
-               time_label = 'time', invert_xaxis=False, 
-               top_label = None, bottom_label = None): 
+               invert_xaxis=False, top_label = None, bottom_label = None): 
     '''
     Represent y = f(x) as an Ed Hawkins "warming stripes" pattern
-    
+    Uses Matplotlib's pcolormesh'
     Credit: https://esmvalgroup.github.io/ESMValTool_Tutorial/files/warming_stripes.py
     
     Parameters
@@ -314,7 +313,7 @@ def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
     y : array
         Dependent variable (asumees centered and normalized to unit standard deviation)
     cmap: str
-        seaborn-friendly colormap 
+        colormap name
     figsize : list
         a list of two integers indicating the figure size
     ax : pyplot.axis
@@ -335,8 +334,7 @@ def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
         value controlling the horizontal offset between stripes and labels (default = 0.05)
     show_xaxis : bool
         flag indicating whether or not the x-axis should be shown (default = False)
-    time_label : str
-        string for the time axis
+    
     savefig_settings : dict
         the dictionary of arguments for plt.savefig(); some notes below:
         - "path" must be specified; it can be any existing or non-existing path,
@@ -347,7 +345,7 @@ def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
         
     See Also
     --------
-    https://seaborn.pydata.org/tutorial/color_palettes.html#sequential-color-palettes
+    https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.pcolormesh.html
     https://matplotlib.org/stable/tutorials/colors/colormapnorms.html
    
     Returns
@@ -365,27 +363,26 @@ def stripes_xy(x, y, cmap='coolwarm', figsize=None, ax=None,
         label_size = mpl.rcParams['axes.labelsize']
 
     ones = np.array([0, 1])
+    #ax.set_axis_off()
     ax.pcolormesh(x, ones, np.vstack([y, y]), cmap=cmap, 
                   vmin=vmin, vmax=vmax, shading='auto')
+    # hide y axis
     ax.get_yaxis().set_visible(False)
+    ax.spines['left'].set_visible(False)
+    # manage x axis
+    ax.spines['bottom'].set_visible(show_xaxis)
     ax.get_xaxis().set_visible(show_xaxis)
-
-    if show_xaxis:
-        if time_label is not None:
-            ax.set_xlabel(time_label)
+    if show_xaxis is True and xlabel is not None:
+        ax.set_xlabel(xlabel)
     
-
     # parameters for label position
     thickness = ax.get_ybound()[1]
     xmax = ax.get_xbound()[1]*(1+x_offset/10)
     #xmax = x.max()*0.8*(1+x_offset)
-    ax.text(xmax, 0.4*thickness, top_label, color=label_color, 
+    ax.text(xmax, 0.5*thickness, top_label, color=label_color, 
             fontsize=label_size, fontweight = 'bold')
-    ax.text(xmax, -0.1*thickness, bottom_label, color=label_color,
+    ax.text(xmax, 0*thickness, bottom_label, color=label_color,
             fontsize=label_size)
-
-    if xlabel is not None:
-        ax.set_xlabel(xlabel)
 
     if ylabel is not None:
         ax.set_ylabel(ylabel)


### PR DESCRIPTION
@khider since you had reported the issue, you have the honor of reviewing the PR. I've redesigned the code so it utilizes MPL's pcolormesh under the hood, which has the added benefit of allowing for multiple colormaps (see docstring for examples). 

```
import pyleoclim as pyleo
nino3 = pyleo.utils.load_dataset('NINO3')
fig, ax = nino3.stripes(show_xaxis=True)
```
generates:
![nino3_stripes](https://user-images.githubusercontent.com/13760223/234414919-ad7f1447-38ce-4b25-9420-e77998c08891.png)

while for MultipleSeries, this:
```
import pyleoclim as pyleo
co2ts = pyleo.utils.load_dataset('AACO2')
lr04 = pyleo.utils.load_dataset('LR04')
edc = pyleo.utils.load_dataset('EDC-dD')
ms = lr04.flip() & edc & co2ts # create MS object
fig, ax = ms.stripes(figsize=(8,2.5),show_xaxis=True, sat = 0.8)
```
generates that:
![last800ka_stripes](https://user-images.githubusercontent.com/13760223/234415439-ccf0301c-76e9-4fe4-be3f-3a257522c65f.png)

I have tried to rely on the plotting.py function and make it as general as possible, but it might not be perfect. I need to move on to geoSeries, so this will have to do. It looks like it fixes bug #281 , which is what matters here.