### PR TITLE
fixed series.ssa(): RCk length mismatch in docstring

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -1225,7 +1225,7 @@ class Series:
             RCk = nino_ssa.RCmat[:,:14].sum(axis=1)
             @savefig ssa_recon.png
             fig, ax = ts.plot(title='SOI')
-            ax.plot(time,RCk,label='SSA reconstruction, 14 modes',color='orange')
+            ax.plot(nino_ssa.time,RCk,label='SSA reconstruction, 14 modes',color='orange')
             ax.legend()
             pyleo.closefig(fig)
 


### PR DESCRIPTION
plot was using the original series time rather than nino_ssa time