### PR TITLE
Alleviating the dependency conflict between scipy and cartopy 

### DIFF
--- a/doc_build/anaconda_install.rst
+++ b/doc_build/anaconda_install.rst
@@ -16,8 +16,8 @@ macOS (Intel)
 
   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 
-macOS (Apple Silicone)
-''''''''''
+macOS (Apple Silicon)
+'''''''''''''''''''''
 
 .. code-block:: bash
 

--- a/doc_build/anaconda_install.rst
+++ b/doc_build/anaconda_install.rst
@@ -9,12 +9,19 @@ Users may find it preferable to install the minimalist "miniconda" package.
 Step 1: Download the installation script for miniconda3
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-MacOS
------
+macOS (Intel)
+'''''''''''''
 
 .. code-block:: bash
 
   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+
+macOS (Apple Silicone)
+''''''''''
+
+.. code-block:: bash
+
+  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
 
 Linux
 -----

--- a/doc_build/installation.rst
+++ b/doc_build/installation.rst
@@ -58,9 +58,14 @@ Once the pyleo environment is activated, you'll want to first install Cartopy:
 
 .. code-block:: bash
 
-  conda install -c conda-forge cartopy=0.21
+  conda install cartopy
 
-(note: under Python 3.10, cartopy>=0.21 will be installed by default, so specifying this version is unnecessary).
+To avoid a recent (July 2023) conflict between Cartopy and SciPy v1.11, once may install Statsmodels from conda so that SciPy v1.10 will be installed:
+
+.. code-block:: bash
+
+  conda install statsmodels
+
 Then install Pyleoclim through Pypi, which contains the most stable version of Pyleoclim:
 
 .. code-block:: bash

--- a/doc_build/rtd_env.yml
+++ b/doc_build/rtd_env.yml
@@ -1,11 +1,8 @@
 name: rtd_env
 channels:
-  - conda-forge
   - defaults
 dependencies:
-  - python=3.10
-  - numpy
-  - cartopy
+  - python>=3.9
   - pip:
     - Sphinx<6.0
     - pylint

--- a/doc_build/rtd_env.yml
+++ b/doc_build/rtd_env.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
 dependencies:
   - python>=3.9
+  - cartopy
   - pip:
     - Sphinx<6.0
     - pylint

--- a/environment.yml
+++ b/environment.yml
@@ -8,11 +8,7 @@ channels:
 dependencies:
   - python>=3.9
   - cartopy
-  - nitime
   - numba
-  - pathos
-  - pip
-  - pytest
   - pyyaml
   - requests
   - scikit-learn
@@ -21,7 +17,7 @@ dependencies:
   - tabulate
   - tqdm
   - wget
+  - pip
   - pip:
     - pyhht
     - '-e .'
-    - pandas>=2.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@
 # packages for this repo including running the test suite.
 name: pyleo
 channels:
-  - LinkedEarth
   - conda-forge
   - default
 dependencies:

--- a/environment.yml
+++ b/environment.yml
@@ -8,17 +8,14 @@ channels:
 dependencies:
   - python>=3.9
   - cartopy
-  - matplotlib
   - nitime
   - numba
-  - numpy
   - pathos
   - pip
   - pytest
   - pyyaml
   - requests
   - scikit-learn
-  - scipy=1.10.1
   - seaborn
   - statsmodels
   - tabulate

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@
 # packages for this repo including running the test suite.
 name: pyleo
 channels:
-  - conda-forge
   - default
 dependencies:
   - python>=3.9
@@ -17,6 +16,7 @@ dependencies:
   - tqdm
   - wget
   - pip
+  - pytest
   - pip:
     - pyhht
     - '-e .'

--- a/pyleoclim/utils/wavelet.py
+++ b/pyleoclim/utils/wavelet.py
@@ -2381,7 +2381,7 @@ def wtc(coeff1, coeff2, scales, tau, smooth_factor=0.25):
 
         """
         def fft_kwargs(signal, **kwargs):
-            return {'n': np.int(2 ** np.ceil(np.log2(len(signal))))}
+            return {'n': int(2 ** np.ceil(np.log2(len(signal))))}
 
         W = coeff.transpose()
         m, n = np.shape(W)
@@ -2402,7 +2402,7 @@ def wtc(coeff1, coeff2, scales, tau, smooth_factor=0.25):
 
         # Smooth in scale
         wsize = 0.6 / dj * 2
-        win = rect(np.int(np.round(wsize)), normalize=True)
+        win = rect(int(np.round(wsize)), normalize=True)
         T = signal.convolve2d(T, win[:, np.newaxis], 'same')
         S = T.transpose()
 
@@ -2876,7 +2876,7 @@ def tc_wavelet(Y, dt, scale, mother, param, pad=False):
     if pad == True:
         # power of 2 nearest to N
         base2 = np.fix(np.log(n1) / np.log(2) + 0.4999)
-        nzeroes = (2 ** (base2 + 1) - n1).astype(np.int64)
+        nzeroes = int(2 ** (base2 + 1) - n1)
         x = np.concatenate((x, np.zeros(nzeroes)))
 
     n = len(x)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         "LiPD==0.2.8.8",
         "pandas>=2.0.0",
+        "kneed>=0.7.0",
         "statsmodels>=0.13.2",
         "seaborn>=0.12.0",
         "scikit-learn>=0.24.2",
@@ -41,7 +42,6 @@ setup(
         "nitime>=0.9",
         "tabulate>=0.8.9",
         "Unidecode>=1.1.1",
-        "kneed>=0.7.0",
         "pyyaml",
     ],
     python_requires=">=3.9.0"

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,6 @@ setup(
     install_requires=[
         "LiPD==0.2.8.8",
         "pandas>=2.0.0",
-        "numpy<=1.24.0",
-        "matplotlib>=3.6.0",
-        "scipy>=1.9.1",
         "statsmodels>=0.13.2",
         "seaborn>=0.12.0",
         "scikit-learn>=0.24.2",


### PR DESCRIPTION
Related issue: https://github.com/LinkedEarth/Pyleoclim_util/discussions/450#discussioncomment-6356848

Key Updates:
- `setup.py`: removing unnecessary items: matplotlib, scipy, numpy, which are dependencies of seaborn, statsmodels, etc.
- `environment.yml`: removing unnecessary items. Now the CI is also faster.
- `wavelet.py`: `np.int` is causing error with the latest numpy; replaced with `int`.
- `installation.rst`: emphasizing the importance of `conda install statsmodels` before `pip install pyleoclim` to avoid scipy v1.11.