### PR TITLE
Fix link in `Series` docstring

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -65,7 +65,7 @@ class Series:
 
     * optionally, some metadata about both axes, like units, labels and origin.
 
-    How to create, manipulate and use such objects is described in `PyleoTutorials <https://http://linked.earth/PyleoTutorials/>`_.
+    How to create, manipulate and use such objects is described in `PyleoTutorials <https://linked.earth/PyleoTutorials/>`_.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixed the link to PyleoTutorials in the docstring of `Series`.