### PR TITLE
Fix permil encoding

### DIFF
--- a/pyleoclim/data/metadata.yml
+++ b/pyleoclim/data/metadata.yml
@@ -70,7 +70,7 @@ LR04:
     time_unit: 'ky BP'
     label: 'LR04 benthic stack'
     value_name: '$\delta^{18} \mathrm{O}$'
-    value_unit: '\u2030'
+    value_unit: "\u2030"
     archiveType: 'Marine Sediment'
   time_column: Time (ka)
   value_column: Benthic d18O (per mil)
@@ -104,7 +104,7 @@ EDC-dD:
     time_unit: 'y BP'
     label: 'EPICA Dome C dD'
     value_name: '$\delta \mathrm{D}$'
-    value_unit: '\u2030'
+    value_unit: "\u2030"
     archiveType: 'glacierice'
     sensorType: 'ice sheet'
     observationType: 'hydrogen isotopes'
@@ -120,7 +120,7 @@ GISP2:
   pyleo_kwargs:
     time_unit: 'yr BP'
     time_name: 'Age'
-    value_unit: '\u2030'
+    value_unit: "\u2030"
     value_name: '$\delta^{18} \mathrm{O}$'
     label: 'GISP2'
     archiveType: 'Glacier Ice'
@@ -136,9 +136,9 @@ cenogrid_d18O:
   pyleo_kwargs:
     time_unit: 'My BP'
     time_name: 'Tuned Time'
-    value_unit: '\u2030 VPDB'
+    value_unit: "\u2030 VPDB"
     value_name: '$\delta^{18} \mathrm{O}$'
-    label: 'CENOGRID'
+    label: 'CENOGRID $\delta^{18} \mathrm{O}$'
     archiveType: 'Marine Sediment'
     importedFrom: 'https://doi.pangaea.de/10.1594/PANGAEA.917660'
   time_column: Tuned time [Ma]
@@ -152,9 +152,9 @@ cenogrid_d13C:
   pyleo_kwargs:
     time_unit: 'My BP'
     time_name: 'Tuned Time'
-    value_unit: '\u2030 VPDB'
+    value_unit: "\u2030 VPDB"
     value_name: '$\delta^{13} \mathrm{C}$'
-    label: 'CENOGRID'
+    label: 'CENOGRID $\delta^{13} \mathrm{C}$'
     archiveType: 'Marine Sediment'
     importedFrom: 'https://doi.pangaea.de/10.1594/PANGAEA.917660'
   time_column: Tuned time [Ma]


### PR DESCRIPTION
The recent fix of #482 to address #473 seems to have improved things on the PC side but broke them on the Mac side. Double-quotes seem to work better than single quotes, so I updated metadata.yml accordingly.

To test the new code:

```
import pyleoclim as pyleo
pyleo.utils.available_dataset_names()
for name in ['LR04','EDC-dD','GISP2','cenogrid_d18O','cenogrid_d13C']:
    ts = pyleo.utils.load_dataset(name)
    ts.plot()
```

should yield something like this:

![GISP2](https://github.com/LinkedEarth/Pyleoclim_util/assets/13760223/22a83f8e-949d-4466-bfb9-e83202210249)

