### PR TITLE
Coherence time axis

### DIFF
--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -63,9 +63,6 @@ class MultipleSeries:
                 
     '''
     def __init__(self, series_list, time_unit=None, label=None, name=None):
-        from ..core.series import Series
-        from ..core.geoseries import GeoSeries
-        from ..core.lipdseries import LipdSeries
         
         self.series_list = series_list
         self.time_unit = time_unit
@@ -75,8 +72,11 @@ class MultipleSeries:
             warnings.warn("`name` is a deprecated property, which will be removed in future releases. Please use `label` instead.",
                           DeprecationWarning, stacklevel=2)
         # check that all components are Series
-        if not all([isinstance(ts, (Series, GeoSeries, LipdSeries)) for ts in self.series_list]):
-            raise ValueError('All components must be of the same type')
+        from ..core.series import Series
+        from ..core.geoseries import GeoSeries
+        from ..core.lipdseries import LipdSeries
+        #if not all([isinstance(ts, (Series, GeoSeries, LipdSeries)) for ts in self.series_list]):
+        #    raise ValueError('All components must be of the same type')
 
         if self.time_unit is not None:
             new_ts_list = []

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -75,8 +75,9 @@ class MultipleSeries:
         from ..core.series import Series
         from ..core.geoseries import GeoSeries
         from ..core.lipdseries import LipdSeries
-        #if not all([isinstance(ts, (Series, GeoSeries, LipdSeries)) for ts in self.series_list]):
-        #    raise ValueError('All components must be of the same type')
+        
+        if not all([isinstance(ts, (Series, GeoSeries, LipdSeries)) for ts in self.series_list]):
+            raise ValueError('All components must be of the same type')
 
         if self.time_unit is not None:
             new_ts_list = []

--- a/pyleoclim/core/scalograms.py
+++ b/pyleoclim/core/scalograms.py
@@ -15,27 +15,6 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from scipy.stats.mstats import mquantiles
 
 #from ..core import MultipleScalogram
-def infer_period_unit_from_time_unit(time_unit):
-    ''' infer a period unit based on the given time unit
-
-    '''
-    if time_unit is None:
-        period_unit = None
-    else:
-        unit_group = lipdutils.timeUnitsCheck(time_unit)
-        if unit_group != 'unknown':
-            if unit_group == 'kage_units':
-                period_unit = 'kyrs'
-            else:
-                period_unit = 'yrs'
-        else:
-            if time_unit[-1] == 's':
-                period_unit = time_unit
-            else:
-                period_unit = f'{time_unit}s'
-
-    return period_unit
-
 
 class Scalogram:
     '''
@@ -159,7 +138,7 @@ class Scalogram:
         if scale_unit is not None:
             self.scale_unit = scale_unit
         elif timeseries is not None:
-            self.scale_unit = infer_period_unit_from_time_unit(timeseries.time_unit)
+            self.scale_unit = plotting.infer_period_unit_from_time_unit(timeseries.time_unit)
         else:
             self.scale_unit = None
 

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -117,7 +117,7 @@ class Series:
         Defaults to 'ascending'
 
     verbose : bool
-        If True, will print warning messages if there is any
+        If True, will print warning messages if there are any
 
     clean_ts : boolean flag
          set to True to remove the NaNs and make time axis strictly prograde with duplicated timestamps reduced by averaging the values
@@ -151,8 +151,9 @@ class Series:
         value = np.array(value)
 
         if auto_time_params is None:
-            warnings.warn('auto_time_params is not specified. Currently default behavior sets this to True. In a future release, this will be changed to False.', UserWarning, stacklevel=2)
             auto_time_params = True
+            if verbose:
+                warnings.warn('auto_time_params is not specified. Currently default behavior sets this to True, which might modify your supplied time metadata.  Please set to False if you want a different behavior.', UserWarning, stacklevel=2)
 
         if auto_time_params:
             # assign time metadata if they are not provided or provided incorrectly

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3201,7 +3201,21 @@ class Series:
              coh_wwz.plot()
 
         As with wavelet analysis, both CWT and WWZ admit optional arguments through `settings`.
-        Significance is assessed similarly as with PSD or Scalogram objects:
+        For instance, one can adjust the resolution of the time axis on which coherence is evaluated:
+            
+        .. jupyter-execute::
+
+             coh_wwz = ts_air.wavelet_coherence(ts_nino, method = 'wwz', settings = {'ntau':20})
+             coh_wwz.plot()
+             
+        The frequency (scale) axis can also be customized, e.g. to focus on scales from 1 to 20y, with 24 scales:
+        
+        .. jupyter-execute::
+            
+             coh = ts_air.wavelet_coherence(ts_nino, freq_kwargs={'fmin':1/20,'fmax':1,'nf':24})
+             coh.plot()
+        
+        Significance is assessed similarly to PSD or Scalogram objects:
 
         .. jupyter-execute::
 
@@ -3219,6 +3233,8 @@ class Series:
             cwt_sig.dashboard()
 
         Note: this design balances many considerations, and is not easily customizable.
+        
+        
         '''
         if not verbose:
             warnings.simplefilter('ignore')

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3235,8 +3235,9 @@ class Series:
         freq_kwargs = {} if freq_kwargs is None else freq_kwargs.copy()
         freq = specutils.make_freq_vector(self.time, method=freq_method, **freq_kwargs)
         args = {}
-        args['wwz'] = {'freq': freq}
+        args['wwz'] = {'freq': freq, 'verbose': verbose}
         args['cwt'] = {'freq': freq}
+        
 
         # put on same time axes if necessary
         if method == 'cwt' and not np.array_equal(self.time, target_series.time):
@@ -3262,12 +3263,17 @@ class Series:
             else:
                 ntau = np.min([np.size(ts1.time), np.size(ts2.time), 50])
 
-            tau = np.linspace(np.min(self.time), np.max(self.time), ntau)
             if 'tau' in settings.keys():
                 tau = settings['tau']
+            else:
+                lb1, ub1 = np.min(ts1.time), np.max(ts1.time)
+                lb2, ub2 = np.min(ts2.time), np.max(ts2.time)
+                lb = np.max([lb1, lb2])
+                ub = np.min([ub1, ub2])
+
+                tau = np.linspace(lb, ub, ntau)
             settings.update({'tau': tau})
             
-
         args[method].update(settings)
 
         # Apply WTC method

--- a/pyleoclim/tests/conftest.py
+++ b/pyleoclim/tests/conftest.py
@@ -35,6 +35,13 @@ def metadata():
     }
 
 @pytest.fixture
+def gen_ts():
+    """ Generate realistic-ish Series for testing """
+    t,v = pyleo.utils.gen_ts(model='colored_noise',nt=50)
+    ts = pyleo.Series(t,v, verbose=False)
+    return ts
+
+@pytest.fixture
 def unevenly_spaced_series():
     """Pyleoclim series with unevenly spaced time axis"""
     length = 10

--- a/pyleoclim/tests/test_core_Coherence.py
+++ b/pyleoclim/tests/test_core_Coherence.py
@@ -17,48 +17,37 @@ Notes on how to test:
 import pytest
 import pyleoclim as pyleo
 
-
-def gen_ts(model,nt):
-    'wrapper for gen_ts in pyleoclim'
-    
-    t,v = pyleo.utils.gen_ts(model=model,nt=nt)
-    ts=pyleo.Series(t,v)
-    return ts
-
 # Tests below
       
 class TestUiCoherencePlot:
     ''' Tests for Coherence.plot()
     '''
 
-    def test_plot_t0(self):
+    def test_plot_t0(self, gen_ts):
         ''' Test Coherence.plot with default parameters
         '''
-        nt = 200
-        ts1 = gen_ts(model='colored_noise', nt=nt)
-        ts2 = gen_ts(model='colored_noise', nt=nt)
+        ts1 = gen_ts
+        ts2 = gen_ts
         coh = ts2.wavelet_coherence(ts1)
         fig,ax = coh.plot()
         pyleo.closefig(fig)
     
-    def test_plot_t1(self):
+    def test_plot_t1(self, gen_ts):
         ''' Test Coherence.plot WTC with significance
         '''
-        nt = 200
-        ts1 = gen_ts(model='colored_noise', nt=nt)
-        ts2 = gen_ts(model='colored_noise', nt=nt)
+        ts1 = gen_ts
+        ts2 = gen_ts
         coh = ts2.wavelet_coherence(ts1)
         
         coh_signif = coh.signif_test(number=10,qs = [0.8, 0.9, .95])
         fig,ax = coh_signif.plot(signif_thresh=0.99)
         pyleo.closefig(fig)
         
-    def test_plot_t2(self):
+    def test_plot_t2(self, gen_ts):
         ''' Test Coherence.plot XWT with significance
         '''
-        nt = 200
-        ts1 = gen_ts(model='colored_noise', nt=nt)
-        ts2 = gen_ts(model='colored_noise', nt=nt)
+        ts1 = gen_ts
+        ts2 = gen_ts
         coh = ts2.wavelet_coherence(ts1)
         
         coh_signif = coh.signif_test(number=10)
@@ -68,22 +57,20 @@ class TestUiCoherencePlot:
 class TestUiCoherenceDashboard:
     ''' Tests for Coherence.dashboard()
     '''        
-    def test_dashboard_t0(self):
+    def test_dashboard_t0(self, gen_ts):
         ''' Test Coherence.dashboard() with default parameters
         '''
-        nt = 200
-        ts1 = gen_ts(model='colored_noise', nt=nt)
-        ts2 = gen_ts(model='colored_noise', nt=nt)
+        ts1 = gen_ts
+        ts2 = gen_ts
         coh = ts2.wavelet_coherence(ts1)
         fig,ax  = coh.dashboard()
         pyleo.closefig(fig)
         
-    def test_dashboard_t1(self):
+    def test_dashboard_t1(self, gen_ts):
         ''' Test Coherence.dashboard() with optional parameter
         '''
-        nt = 200
-        ts1 = gen_ts(model='colored_noise', nt=nt)
-        ts2 = gen_ts(model='colored_noise', nt=nt)
+        ts1 = gen_ts
+        ts2 = gen_ts
         coh = ts2.wavelet_coherence(ts1)
         fig, ax = coh.dashboard(wavelet_plot_kwargs={'contourf_style':{'cmap': 'cividis'}})
         pyleo.closefig(fig)
@@ -91,11 +78,10 @@ class TestUiCoherenceDashboard:
 class TestUiCoherencePhaseStats:
     ''' Tests for Coherence.phase_stats()
     '''        
-    def test_phasestats_t0(self):
+    def test_phasestats_t0(self, gen_ts):
         ''' Test Coherence.phase_stats() with default parameters
         '''
-        nt = 200
-        ts1 = gen_ts(model='colored_noise', nt=nt)
-        ts2 = gen_ts(model='colored_noise', nt=nt)
+        ts1 = gen_ts
+        ts2 = gen_ts
         coh = ts2.wavelet_coherence(ts1)
-        phase = coh.phase_stats(scales=[2,8])
+        _ = coh.phase_stats(scales=[2,8])

--- a/pyleoclim/tests/test_core_MultipleSeries.py
+++ b/pyleoclim/tests/test_core_MultipleSeries.py
@@ -18,25 +18,20 @@ import pandas as pd
 import os
 
 from numpy.testing import assert_array_equal, assert_allclose
-#from pandas.testing import assert_frame_equal
-
 import pytest
-#from urllib.request import urlopen
-#import json
 
 import pyleoclim as pyleo
 from pyleoclim.utils.tsmodel import (
     ar1_sim,
     colored_noise,
 )
-# from pyleoclim.utils.decomposition import mcpca
 
 # a collection of useful functions
 
 def gen_ts(model, nt, alpha, t=None):
     'wrapper for gen_ts in pyleoclim'
     t, v = pyleo.utils.gen_ts(model=model, nt=nt, alpha=alpha, t=t)
-    ts = pyleo.Series(t, v)
+    ts = pyleo.Series(t, v, verbose=False,auto_time_params=True)
     return ts
 
 def gen_normal(loc=0, scale=1, nt=100):

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -35,14 +35,14 @@ from statsmodels.tsa.arima_process import arma_generate_sample
 
 # a collection of useful functions
 
-def gen_ts(model='colored_noise',alpha=1, nt=100, f0=None, m=None, seed=None):
+def gen_ts(model='colored_noise',alpha=1, nt=50, f0=None, m=None, seed=None):
     'wrapper for gen_ts in pyleoclim'
 
     t,v = pyleo.utils.gen_ts(model=model,alpha=alpha, nt=nt, f0=f0, m=m, seed=seed)
     ts=pyleo.Series(t,v, verbose=False, auto_time_params=True)
     return ts
 
-def gen_normal(loc=0, scale=1, nt=100):
+def gen_normal(loc=0, scale=1, nt=20):
     ''' Generate random data with a Gaussian distribution
     '''
     t = np.arange(nt)
@@ -975,11 +975,10 @@ class TestUISeriesWaveletCoherence():
     def test_xwave_t4(self):
        ''' Test Series.wavelet_coherence() with specified frequency parameters
        '''
-       nt = 100
-       ts1 = gen_ts(model='colored_noise', nt=nt)
-       ts2 = gen_ts(model='colored_noise', nt=nt)
+       ts1 = gen_ts(model='colored_noise')
+       ts2 = gen_ts(model='colored_noise')
        nf = 10
-       fmin = 1/(nt//2)
+       fmin = 1/(len(ts1.time)//2)
        fmax = 10*fmin
        scal = ts1.wavelet_coherence(ts2,method='cwt',freq_kwargs={'fmin':fmin,'fmax':fmax,'nf':nf})  
        freq = pyleo.utils.wavelet.freq_vector_log(ts1.time, fmin=fmin, fmax=fmax, nf=nf)
@@ -994,7 +993,7 @@ class TestUISeriesWaveletCoherence():
        _ = ts1.wavelet_coherence(ts2,method='wwz',settings={'ntau':10})  
        
     def test_xwave_t6(self):
-       ''' Test Series.wavelet_coherence() with WWZ with specified ntau
+       ''' Test Series.wavelet_coherence() with WWZ with specified tau
        '''
        ts1 = gen_ts(model='colored_noise')
        ts2 = gen_ts(model='colored_noise')
@@ -1225,12 +1224,12 @@ class TestUISeriesSort:
 
     @pytest.mark.parametrize('keep_log',[True,False])
     def test_sort_t0(self,keep_log):
-        ts = gen_ts(nt=500,alpha=1.0)
+        ts = gen_ts(nt=50,alpha=1.0)
         ts = ts.sort()
         np.all(np.diff(ts.time) >= 0)
 
     def test_sort_t1(self):
-        t = np.arange(500,0,-1)
+        t = np.arange(50,0,-1)
         v = np.ones(len(t))
         ts = pyleo.Series(t,v)
         ts.sort()

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -464,7 +464,7 @@ class TestUISeriesSlice:
     We commit slices at known time intervals and check minimum and maximum values'''
 
     def test_slice(self):
-        ts = gen_normal()
+        ts = gen_normal(nt=100)
         ts_slice = ts.slice(timespan = (10, 50, 80, 90))
         times = ts_slice.__dict__['time']
 

--- a/pyleoclim/utils/plotting.py
+++ b/pyleoclim/utils/plotting.py
@@ -11,11 +11,37 @@ import matplotlib.pyplot as plt
 import pathlib
 import matplotlib as mpl
 import numpy as np
-import pandas as pd
-from matplotlib.patches import Rectangle
-from matplotlib.collections import PatchCollection
-from matplotlib.colors import ListedColormap
-import seaborn as sns
+from ..utils import lipdutils
+
+# import pandas as pd
+# from matplotlib.patches import Rectangle
+# from matplotlib.collections import PatchCollection
+# from matplotlib.colors import ListedColormap
+# import seaborn as sns
+
+# this is here because it's only used to set labels in plots
+def infer_period_unit_from_time_unit(time_unit):
+    ''' infer a period unit based on the given time unit
+
+    '''
+    if time_unit is None:
+        period_unit = None
+    else:
+        unit_group = lipdutils.timeUnitsCheck(time_unit)
+        if unit_group != 'unknown':
+            if unit_group == 'kage_units':
+                period_unit = 'kyrs'
+            else:
+                period_unit = 'yrs'
+        else:
+            period_unit = f'{time_unit}'
+            # if time_unit[-1] == 's':
+            #     period_unit = time_unit
+            # else:
+            #     period_unit = f'{time_unit}s'
+
+    return period_unit
+
 
 
 def scatter_xy(x,y,c=None, figsize=None, xlabel=None, ylabel=None, title=None, 

--- a/pyleoclim/utils/wavelet.py
+++ b/pyleoclim/utils/wavelet.py
@@ -1541,7 +1541,7 @@ def wwz(ys, ts, tau=None, ntau=None, freq=None, freq_method='log',
     return res
 
 
-def wwz_coherence(ys1, ts1, ys2, ts2, smooth_factor=0.25,
+def wwz_coherence(y1, t1, y2, t2, smooth_factor=0.25,
                   tau=None, freq=None, freq_method='log', freq_kwargs=None,
                   c=1/(8*np.pi**2), Neff_threshold=3, nproc=8, detrend=False, sg_kwargs=None,
                   verbose=False,  method='Kirchner_numba',
@@ -1551,19 +1551,19 @@ def wwz_coherence(ys1, ts1, ys2, ts2, smooth_factor=0.25,
     Parameters
     ----------
 
-    ys1 : array
+    y1 : array
 
         first of two time series
 
-    ys2 : array
+    y2 : array
 
         second of the two time series
 
-    ts1 : array
+    t1 : array
 
         time axis of first time series
 
-    ts2 : array
+    t2 : array
 
         time axis of the second time series
 
@@ -1664,27 +1664,26 @@ def wwz_coherence(ys1, ts1, ys2, ts2, smooth_factor=0.25,
 
     '''
     
-    if standardize == True:
+    if standardize:
         warnings.warn('Standardizing the timeseries')
-
-    # TODO: should this use common_time()?
+    
     if tau is None:
-        lb1, ub1 = np.min(ts1), np.max(ts1)
-        lb2, ub2 = np.min(ts2), np.max(ts2)
+        lb1, ub1 = np.min(t1), np.max(t1)
+        lb2, ub2 = np.min(t2), np.max(t2)
         lb = np.max([lb1, lb2])
         ub = np.min([ub1, ub2])
 
-        inside = ts1[(ts1>=lb) & (ts1<=ub)]
+        inside = t1[(t1>=lb) & (t1<=ub)]
         tau = np.linspace(lb, ub, np.size(inside)//10)
         print(f'Setting tau={tau[:3]}...{tau[-3:]}, ntau={np.size(tau)}')
 
     if freq is None:
         freq_kwargs = {} if freq_kwargs is None else freq_kwargs.copy()
-        freq = make_freq_vector(ts1, method=freq_method, **freq_kwargs)
-        print(f'Setting freq={freq[:3]}...{freq[-3:]}, nfreq={np.size(freq)}')
+        freq = make_freq_vector(t1, method=freq_method, **freq_kwargs)
+        print(f'Setting freq={freq[:3]}...{freq[-3:]}, nf={np.size(freq)}')
 
-    ys1_cut, ts1_cut, freq1, tau1 = prepare_wwz(ys1, ts1, freq=freq, tau=tau)
-    ys2_cut, ts2_cut, freq2, tau2 = prepare_wwz(ys2, ts2, freq=freq, tau=tau)
+    y1_cut, t1_cut, freq1, tau1 = prepare_wwz(y1, t1, freq=freq, tau=tau)
+    y2_cut, t2_cut, freq2, tau2 = prepare_wwz(y2, t2, freq=freq, tau=tau)
 
     if np.any(tau1 != tau2):
         if verbose: print('inconsistent `tau`, recalculating...')
@@ -1707,10 +1706,10 @@ def wwz_coherence(ys1, ts1, ys2, ts2, smooth_factor=0.25,
     if freq[0] == 0:
         freq = freq[1:] # delete 0 frequency if present
 
-    res_wwz1 = wwz(ys1_cut, ts1_cut, tau=tau, freq=freq, c=c, Neff_threshold=Neff_threshold,
+    res_wwz1 = wwz(y1_cut, t1_cut, tau=tau, freq=freq, c=c, Neff_threshold=Neff_threshold,
                    nproc=nproc, detrend=detrend, sg_kwargs=sg_kwargs,
                    gaussianize=gaussianize, standardize=standardize, method=method)
-    res_wwz2 = wwz(ys2_cut, ts2_cut, tau=tau, freq=freq, c=c, Neff_threshold=Neff_threshold, 
+    res_wwz2 = wwz(y2_cut, t2_cut, tau=tau, freq=freq, c=c, Neff_threshold=Neff_threshold, 
                    nproc=nproc, detrend=detrend, sg_kwargs=sg_kwargs,
                    gaussianize=gaussianize, standardize=standardize, method=method)
 
@@ -2657,7 +2656,7 @@ def cwt(ys,ts,freq=None,freq_method='log',freq_kwargs={}, scale = None, detrend=
 
     return res
 
-def cwt_coherence(ys1, ts1, ys2, ts2, freq=None, freq_method='log',freq_kwargs={},
+def cwt_coherence(y1, t1, y2, t2, freq=None, freq_method='log',freq_kwargs={},
                   scale = None, detrend=False,sg_kwargs={}, pad = False,
                   standardize = True, gaussianize=False, tau = None, Neff_threshold=3,
                   mother='MORLET',param=None, smooth_factor=0.25):
@@ -2666,26 +2665,26 @@ def cwt_coherence(ys1, ts1, ys2, ts2, freq=None, freq_method='log',freq_kwargs={
     Parameters
     ----------
 
-    ys1 : array
+    y1 : array
 
         first of two time series
 
-    ys2 : array
+    y2 : array
 
         second of the two time series
 
-    ts1 : array
+    t1 : array
 
         time axis of first time series
 
-    ts2 : array
+    t2 : array
 
-        time axis of the second time series (should be = ts1)
+        time axis of the second time series (should be = t1)
 
     tau : array
 
         evenly-spaced time points at which to evaluate coherence 
-        Defaults to None, which uses ts1
+        Defaults to None, which uses t1
 
     freq : array
 
@@ -2776,30 +2775,30 @@ def cwt_coherence(ys1, ts1, ys2, ts2, freq=None, freq_method='log',freq_kwargs={
     pyleoclim.utils.tsutils.preprocess: pre-processes a times series using Gaussianization and detrending.
 
     '''
-    assert np.array_equal(ts1,ts2)  and len(ys1) == len(ys2) , "ts1 and ts2 should be the same. Suggest using common_time()"
+    assert np.array_equal(t1,t2)  and len(y1) == len(y2) , "t1 and t2 should be the same. Suggest using common_time()"
     
     
     if standardize == True:
         warnings.warn('Standardizing the timeseries')
     
     if tau is None:
-        tau = ts1
+        tau = t1
 
     if freq is None:
         freq_kwargs = {} if freq_kwargs is None else freq_kwargs.copy()
-        freq = make_freq_vector(ts1, method=freq_method, **freq_kwargs)
+        freq = make_freq_vector(t1, method=freq_method, **freq_kwargs)
         print(f'Setting freq={freq[:3]}...{freq[-3:]}, nfreq={np.size(freq)}')
   
     if freq[0] == 0:
         freq = freq[1:] # delete 0 frequency if present
 
     #  Compute CWT for both series       
-    cwt1 = cwt(ys1,ts1,freq=freq,freq_method=freq_method,freq_kwargs=freq_kwargs,
+    cwt1 = cwt(y1,t1,freq=freq,freq_method=freq_method,freq_kwargs=freq_kwargs,
                scale = scale, detrend=detrend, sg_kwargs=sg_kwargs,
                gaussianize=gaussianize, standardize=standardize, pad=pad,
                mother=mother,param=param)
     
-    cwt2 = cwt(ys2,ts2,freq=freq,freq_method=freq_method,freq_kwargs=freq_kwargs,
+    cwt2 = cwt(y2,t2,freq=freq,freq_method=freq_method,freq_kwargs=freq_kwargs,
                scale = scale, detrend=detrend, sg_kwargs=sg_kwargs,
                gaussianize=gaussianize, standardize=standardize, pad=pad,
                mother=mother,param=param)


### PR DESCRIPTION
Problem : the original code was creating `tau` based on the left series, not the right. This is now fixed, using the "common_time" rule.  Additionally, the dashboard restricts the view to the period of overlap. Here's a MWE:

```
import pyleoclim as pyleo
SOI = pyleo.utils.load_dataset('SOI')
NINO3 = pyleo.utils.load_dataset('NINO3')
coh_wwz = NINO3.wavelet_coherence(SOI, method='wwz')
fig, ax = coh_wwz.dashboard()
```
The result should look like this:
![coherence_overlap](https://github.com/LinkedEarth/Pyleoclim_util/assets/13760223/251d5d94-0f92-444c-b07d-078ba46602f6)

this should address #479 . TODO: update tutorials
