### PR TITLE
enabling LiPD controlled vocabulary for archiveType

### DIFF
--- a/pyleoclim/core/geoseries.py
+++ b/pyleoclim/core/geoseries.py
@@ -70,14 +70,19 @@ class GeoSeries(Series):
         source of the dataset. If it came from a LiPD file, this could be the datasetID property 
 
     archiveType : string
-        climate archive, one of 'ice-other', 'ice/rock', 'coral', 'documents', 'glacierice', 'hybrid', 'lakesediment', 'marinesediment', 'sclerosponge', 'speleothem', 'wood', 'molluskshells', 'peat', 'midden', 'instrumental', 'model', 'other'                                                                                     
+        climate archive, one of 'Borehole', 'Coral', 'FluvialSediment', 'GlacierIce', 'GroundIce', 'LakeSediment', 'MarineSediment', 'Midden', 'MolluskShell', 'Peat', 'Sclerosponge', 'Shoreline', 'Speleothem', 'TerrestrialSediment', 'Wood'                                                                                   
         Reference: https://lipdverse.org/vocabulary/archivetype/
+    
+    control_archiveType  : [True, False]
+        Whether to standardize the name of the archiveType agains the vocabulary from: https://lipdverse.org/vocabulary/paleodata_proxy/. 
+        If set to True, will only allow for these terms and automatically convert known synonyms to the standardized name. Only standardized variable names will be automatically assigned a color scheme.  
+        Default is False. 
         
     sensorType : string
-        sensor, e.g. a paleoclimate proxy sensor, defined in https://wiki.linked.earth/Category:ProxySensor_(L)
+        sensor, e.g. a paleoclimate proxy sensor. This property can be used to differentiate between species of foraminifera
         
     observationType : string
-        observation type,  e.g. a paleoclimate proxy observation, defined in https://wiki.linked.earth/Category:ProxyObservation_(L)
+        observation type,  e.g. a proxy observation. See https://lipdverse.org/vocabulary/paleodata_proxy/. Note: this is preferred terminology but not enforced
         
     depth : array
         depth at which the values were collected
@@ -119,7 +124,8 @@ class GeoSeries(Series):
 
     def __init__(self, time, value, lat, lon, elevation = None, time_unit=None, time_name=None, 
                  value_name=None, value_unit=None, label=None, importedFrom=None, 
-                 archiveType = None, sensorType = None, observationType = None,
+                 archiveType = None, control_archiveType = False, 
+                 sensorType = None, observationType = None,
                  log=None, keep_log=False, verbose=True,
                  depth = None, depth_name = None, depth_unit= None,
                  sort_ts = 'ascending', dropna = True,  clean_ts=False):
@@ -155,7 +161,7 @@ class GeoSeries(Series):
         # PSM 
         self.sensorType = sensorType
         self.observationType = observationType
-        
+                
         # depth infornation
         self.depth = depth
         self.depth_name = depth_name
@@ -163,7 +169,7 @@ class GeoSeries(Series):
             
         #assign all the rest
         super().__init__(time, value, time_unit, time_name, value_name,
-                         value_unit, label, importedFrom, archiveType,
+                         value_unit, label, importedFrom, archiveType, control_archiveType,
                          log, keep_log, sort_ts, dropna, verbose, clean_ts)
                       
 
@@ -591,8 +597,10 @@ class GeoSeries(Series):
         
         if self.archiveType is not None:
             archiveType = lipdutils.LipdToOntology(self.archiveType).lower().replace(" ", "")
+            if archiveType not in lipdutils.PLOT_DEFAULT.keys():
+                archiveType = 'Other'                
         else: 
-            archiveType = 'other'
+            archiveType = 'Other'
         
         if 'marker' not in plt_kwargs.keys():
             plt_kwargs.update({'marker': lipdutils.PLOT_DEFAULT[archiveType][1]})

--- a/pyleoclim/data/metadata.yml
+++ b/pyleoclim/data/metadata.yml
@@ -71,7 +71,7 @@ LR04:
     label: 'LR04 benthic stack'
     value_name: '$\delta^{18} \mathrm{O}$'
     value_unit: "\u2030"
-    archiveType: 'Marine Sediment'
+    archiveType: 'MarineSediment'
   time_column: Time (ka)
   value_column: Benthic d18O (per mil)
 
@@ -86,7 +86,7 @@ AACO2:
     label: 'EPICA Dome C CO2'
     value_name: '$CO_2$'
     value_unit: 'ppm'
-    archiveType: 'Glacier Ice'
+    archiveType: 'GlacierIce'
     importedFrom: 'https://www.ncei.noaa.gov/pub/data/paleo/icecore/antarctica/antarctica2015co2composite.txt'
   time_column: Age [kyr BP]
   value_column: $CO_2$ [ppm]
@@ -105,7 +105,7 @@ EDC-dD:
     label: 'EPICA Dome C dD'
     value_name: '$\delta \mathrm{D}$'
     value_unit: "\u2030"
-    archiveType: 'glacierice'
+    archiveType: 'GlacierIce'
     sensorType: 'ice sheet'
     observationType: 'hydrogen isotopes'
     importedFrom: 'https://www.ncei.noaa.gov/pub/data/paleo/icecore/antarctica/epica_domec/edc3deuttemp2007.txt'
@@ -123,7 +123,7 @@ GISP2:
     value_unit: "\u2030"
     value_name: '$\delta^{18} \mathrm{O}$'
     label: 'GISP2'
-    archiveType: 'Glacier Ice'
+    archiveType: 'GlacierIce'
     importedFrom: 'https://www.ncei.noaa.gov/access/paleo-search/study/17796'
   time_column: Age [yr BP]
   value_column: d18O [permil]
@@ -139,7 +139,7 @@ cenogrid_d18O:
     value_unit: "\u2030 VPDB"
     value_name: '$\delta^{18} \mathrm{O}$'
     label: 'CENOGRID $\delta^{18} \mathrm{O}$'
-    archiveType: 'Marine Sediment'
+    archiveType: 'MarineSediment'
     importedFrom: 'https://doi.pangaea.de/10.1594/PANGAEA.917660'
   time_column: Tuned time [Ma]
   value_column: Foram bent δ18O [‰ PDB] (VPDB)
@@ -155,7 +155,7 @@ cenogrid_d13C:
     value_unit: "\u2030 VPDB"
     value_name: '$\delta^{13} \mathrm{C}$'
     label: 'CENOGRID $\delta^{13} \mathrm{C}$'
-    archiveType: 'Marine Sediment'
+    archiveType: 'MarineSediment'
     importedFrom: 'https://doi.pangaea.de/10.1594/PANGAEA.917660'
   time_column: Tuned time [Ma]
   value_column: Foram bent δ13C [‰ PDB] (VPDB)

--- a/pyleoclim/tests/conftest.py
+++ b/pyleoclim/tests/conftest.py
@@ -82,7 +82,7 @@ def geometadata():
             'value_unit': '‰',
             'value_name': '$\\delta \\mathrm{D}$',
             'label': 'pink noise geoseries',
-            'archiveType': 'Glacier Ice',
+            'archiveType': 'GlacierIce',
             'importedFrom': 'who knows where',
             'log': None
     }

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -116,7 +116,13 @@ class TestUISeriesInit:
          
          assert datum == 1950
          assert direction == 'retrograde'
-         
+    
+     @pytest.mark.parametrize('archiveType', ['FluvialSediment', 'creek'])
+     def test_init_archiveType(self, archiveType):
+         ts =pyleo.Series(time=[2,3,5], value =[4,5,6], archiveType=archiveType, control_archiveType=True)
+        
+         assert ts.archiveType=='FluvialSediment'
+          
 
 class TestSeriesIO:
     ''' Test Series import from and export to other formats
@@ -1241,7 +1247,7 @@ class TestResample:
             'value_unit': 'mb',
             'value_name': 'SOI',
             'label': f'Southern Oscillation Index ({rule} resampling)',
-            'archiveType': 'instrumental',
+            'archiveType': 'Instrumental',
             'importedFrom': None,
             'log': (
                     {0: 'dropna', 'applied': True, 'verbose': True},
@@ -1283,7 +1289,7 @@ class TestResample:
             'value_unit': 'mb',
             'value_name': 'SOI',
             'label': f'Southern Oscillation Index ({rule} resampling)',
-            'archiveType': 'instrumental',
+            'archiveType': 'Instrumental',
             'importedFrom': None,
             'log': (
                     {0: 'dropna', 'applied': True, 'verbose': True},

--- a/pyleoclim/utils/mapping.py
+++ b/pyleoclim/utils/mapping.py
@@ -530,17 +530,24 @@ def make_df(geo_ms, hue=None, marker=None, size=None, cols=None, d=None):
     lats = [geos.lat for geos in geo_series_list]
     lons = [geos.lon for geos in geo_series_list]
 
-    traits = [hue, marker, size]
+    traits = [hue, marker, size]   
     if type(cols) == list:
         traits += cols
     value_d = {'lat': lats, 'lon': lons}
+    
+
     for trait in traits:  # trait_d.keys():
         # trait = trait_d[trait_key]
         if trait != None:
-            trait_vals = [geos.__dict__[trait] if trait in geos.__dict__.keys() else None for geos in
+            if trait == 'archiveType':
+                trait_vals = [LipdToOntology(geos.__dict__[trait]) if trait in geos.__dict__.keys() else None for geos in
                           geo_series_list]
+            else: 
+                trait_vals = [geos.__dict__[trait] if trait in geos.__dict__.keys() else None for geos in
+                              geo_series_list]
             value_d[trait] = [trait_val if trait_val != 'None' else None for trait_val in trait_vals]
 
+        
     geos_df = pd.DataFrame(value_d)
     if type(d) == dict:
         for trait in d.keys():

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "Unidecode>=1.1.1",
         "cartopy>=0.22.0",
         "pyyaml",
+        "beautifulsoup4",        
     ],
     python_requires=">=3.9.0"
 )


### PR DESCRIPTION
This pull request addresses issue #421. 

- `archiveType` in Series (and by extension, GeoSeries) is now an open field and is not overwritten when not in the controlled vocabulary. users can do so by setting `control_archiveType` to True. In this case, there is an attempt to guess based on capitalization and known synonyms from the lipdverse vocabulary. If can't make a guess, errors out
- Changed the global plotting dictionary for mapping using LiPD archive types. If not standardized, will use "other" for plotting. 