### PR TITLE
updated sphinx-search extension version

### DIFF
--- a/doc_build/rtd_env.yml
+++ b/doc_build/rtd_env.yml
@@ -14,7 +14,7 @@ dependencies:
     - numpydoc>=1.1.0
     - nbsphinx
     - IPython
-    - readthedocs-sphinx-search>=0.1.0
+    - readthedocs-sphinx-search>=0.3.2
     - sphinx-rtd-theme>=1.0.0
     - jupyter-sphinx
     - sphinx-copybutton


### PR DESCRIPTION
cf RTD email from Jan 15:


> Recently, we identified a security vulnerability in our readthedocs-sphinx-search Sphinx extension. We have detected that you have used this extension in your builds in the last six months, in the following projects:pyleoclim-utilThis vulnerability could allow an attacker to inject arbitrary HTML content when including search results from a malicious project, using the project:<malicious-project> search filter in a malicious link like https://docs.example.com/en/latest/?rtd_search=project:<malicious-project> query, for instance.If you no longer use this extension, feel free to disregard this message. Otherwise, we strongly recommend updating to the latest version (0.3.2) as soon as possible.Alternatively, you can try our new search integration from our addons project, which will replace the Sphinx extension in the future. You can enable it from our beta dashboard at https://beta.readthedocs.org, by navigating to your project's Settings page, and clicking on the Addons tab.Documentation sites from Read the Docs Community (*.readthedocs.io and custom domains), don't use of session cookies, so what an attacker could do is very limited. You can find more information about this vulnerability in our security advisory.
> --
> Keep documenting,Read the Docs
> 
> Recently, we identified a [security vulnerability](https://urldefense.com/v3/__https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj__;!!LIr3w8kk_Xxm!tt8pa7jws0IDVrOVKPD5nt129O6wBizQCNItZe9yj7W2TH2YPRj2l106UNAtFR6JPK-jfMOOP1rNJSJeg_1g$) in our [readthedocs-sphinx-search](https://urldefense.com/v3/__https://pypi.org/project/readthedocs-sphinx-search/__;!!LIr3w8kk_Xxm!tt8pa7jws0IDVrOVKPD5nt129O6wBizQCNItZe9yj7W2TH2YPRj2l106UNAtFR6JPK-jfMOOP1rNJZLt0V4N$) Sphinx extension. We have detected that you have used this extension in your builds in the last six months, in the following projects:
> 
> [pyleoclim-util](https://urldefense.com/v3/__https://readthedocs.org/projects/pyleoclim-util/__;!!LIr3w8kk_Xxm!tt8pa7jws0IDVrOVKPD5nt129O6wBizQCNItZe9yj7W2TH2YPRj2l106UNAtFR6JPK-jfMOOP1rNJfpCcBNE$)
> This vulnerability could allow an attacker to inject arbitrary HTML content when including search results from a malicious project, using the project:<malicious-project> search filter in a malicious link like [https://docs.example.com/en/latest/?rtd_search=project:<malicious-project>](https://urldefense.com/v3/__https://docs.example.com/en/latest/?rtd_search=project:*3Cmalicious-project*3E__;JSU!!LIr3w8kk_Xxm!tt8pa7jws0IDVrOVKPD5nt129O6wBizQCNItZe9yj7W2TH2YPRj2l106UNAtFR6JPK-jfMOOP1rNJfSavF35$) query, for instance.
> 
> If you no longer use this extension, feel free to disregard this message. Otherwise, we strongly recommend updating to the latest version (0.3.2) as soon as possible.
> 
> Alternatively, you can try our new search integration from our [addons project](https://urldefense.com/v3/__https://blog.readthedocs.com/addons-flyout-menu-beta/__;!!LIr3w8kk_Xxm!tt8pa7jws0IDVrOVKPD5nt129O6wBizQCNItZe9yj7W2TH2YPRj2l106UNAtFR6JPK-jfMOOP1rNJSI6K08W$), which will replace the Sphinx extension in the future. You can enable it from our beta dashboard at [https://beta.readthedocs.org](https://urldefense.com/v3/__https://beta.readthedocs.org__;!!LIr3w8kk_Xxm!tt8pa7jws0IDVrOVKPD5nt129O6wBizQCNItZe9yj7W2TH2YPRj2l106UNAtFR6JPK-jfMOOP1rNJYNuQ2Cg$), by navigating to your project's Settings page, and clicking on the Addons tab.
> 
> Documentation sites from Read the Docs Community (*.[readthedocs.io](http://readthedocs.io/) and custom domains), don't use of session cookies, so what an attacker could do is very limited. You can find more information about this vulnerability in our [security advisory](https://urldefense.com/v3/__https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj__;!!LIr3w8kk_Xxm!tt8pa7jws0IDVrOVKPD5nt129O6wBizQCNItZe9yj7W2TH2YPRj2l106UNAtFR6JPK-jfMOOP1rNJSJeg_1g$).
> 
> Keep documenting,
> Read the Docs