### PR TITLE
quantiles calculations

### DIFF
--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -131,8 +131,8 @@ class EnsembleSeries(MultipleSeries):
 
     
 
-    def quantiles(self, qs=[0.05, 0.5, 0.95], mode = 'value'):
-        '''Calculate quantiles of an EnsembleSeries object. If mode is 'paleo', the calculation requires for the time axis to be the same. You can use the common_time method to do so. In essence, it transforms the time uncertainty into a y-axis uncertainty. If mode is 'chron', the values should be the same for all members of the emsemble. 
+    def quantiles(self, qs=[0.05, 0.5, 0.95], axis = 'value'):
+        '''Calculate quantiles of an EnsembleSeries object. If axis is 'value', the calculation requires for the time axis to be the same. You can use the common_time method to do so. In essence, it transforms the time uncertainty into a y-axis uncertainty. If axis is 'time', the values should be the same for all members of the emsemble. 
 
         Reuses [scipy.stats.mstats.mquantiles](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mstats.mquantiles.html) function.
 
@@ -143,7 +143,7 @@ class EnsembleSeries(MultipleSeries):
 
             List of quantiles to consider for the calculation. The default is [0.05, 0.5, 0.95].
         
-        mode : ['time', 'value']
+        axis : ['time', 'value']
             
             Whether to calculate the quantiles over the values or time. Default is 'value'. 
 
@@ -199,10 +199,10 @@ class EnsembleSeries(MultipleSeries):
             
             time_ens = pyleo.EnsembleSeries(series_list)
             
-            ens_qs = time_ens.quantiles(mode='time')            
+            ens_qs = time_ens.quantiles(axis='time')            
 
         '''
-        if mode == 'value':
+        if axis == 'value':
             time = np.copy(self.series_list[0].time)
             vals = []
             for ts in self.series_list:
@@ -220,7 +220,7 @@ class EnsembleSeries(MultipleSeries):
                 ts = Series(time=time, value=quant, label=f'{qs[i]*100:g}%', verbose=False)
                 ts_list.append(ts)
         
-        elif mode == 'time':
+        elif axis == 'time':
             
             value = np.copy(self.series_list[0].value)
             vals = []
@@ -240,7 +240,7 @@ class EnsembleSeries(MultipleSeries):
                 ts_list.append(ts)
         
         else:
-            raise ValueError("Mode should be either 'value' or 'time'")
+            raise ValueError("Axis should be either 'value' or 'time'")
 
         ens_qs = EnsembleSeries(series_list=ts_list)
 
@@ -1053,20 +1053,20 @@ class EnsembleSeries(MultipleSeries):
         else:
             return ax
 
-    def to_dataframe(self, mode = 'value'):
+    def to_dataframe(self, axis = 'value'):
         '''
         Export the ensemble as a Pandas DataFrame, with members of the ensemble as columns. The columns are labeled according to the label in the individual series or numbered if 'label' is None.
         
 
         Parameters
         ----------
-        mode : str, ['time', 'value']
+        axis : str, ['time', 'value']
             Whether the return the ensemble from value or time. each The default is 'value'.
 
         Raises
         ------
         ValueError
-            Mode should be either 'time' or 'value'
+            Axis should be either 'time' or 'value'
 
         Returns
         -------
@@ -1089,16 +1089,16 @@ class EnsembleSeries(MultipleSeries):
                 series_list.append(ts)
             
             time_ens = pyleo.EnsembleSeries(series_list)
-            ens_qs = time_ens.quantiles(mode='time')
+            ens_qs = time_ens.quantiles(axis='time')
             
-            df=ens_qs.to_dataframe(mode='time')
+            df=ens_qs.to_dataframe(axis='time')
 
         '''
         
         df_dict = {}
         idx = 0
         
-        if mode == 'value':
+        if axis == 'value':
             for ts in self.series_list:
                 if ts.label is None:
                     df_dict[idx]=ts.value
@@ -1106,7 +1106,7 @@ class EnsembleSeries(MultipleSeries):
                     df_dict[ts.label]=ts.value
                 idx+=1
         
-        elif mode == 'time':
+        elif axis == 'time':
             for ts in self.series_list:
                 if ts.label is None:
                     df_dict[idx]=ts.time
@@ -1115,19 +1115,19 @@ class EnsembleSeries(MultipleSeries):
                 idx+=1
         
         else:
-            raise ValueError('Mode should be either "time" or "value"')
+            raise ValueError('Axis should be either "time" or "value"')
             
         df = pd.DataFrame(df_dict)
         
         return df
     
-    def to_array(self, mode='value', labels=True):
+    def to_array(self, axis='value', labels=True):
         '''
         Returns an ensemble as a numpy array with an optional list for labels. Each column in the array corresponds to an ensemble member.
 
         Parameters
         ----------
-        mode : str, ['time', 'value'], optional
+        axis : str, ['time', 'value'], optional
             Whether the return the ensemble from value or time. The default is 'value'.
         labels : bool, [True,False], optional
             Whether to retrun a separate list with the timseries labels. The default is True.
@@ -1135,7 +1135,7 @@ class EnsembleSeries(MultipleSeries):
         Raises
         ------
         ValueError
-            Mode should be either 'time' or 'value'
+            Axis should be either 'time' or 'value'
 
         Returns
         -------
@@ -1164,27 +1164,27 @@ class EnsembleSeries(MultipleSeries):
                 series_list.append(ts)
             
             time_ens = pyleo.EnsembleSeries(series_list)
-            ens_qs = time_ens.quantiles(mode='time')
+            ens_qs = time_ens.quantiles(axis='time')
             
-            vals,headers=ens_qs.to_dataframe(mode='time')    
+            vals,headers=ens_qs.to_dataframe(axis='time')    
 
         '''
         
         vals=np.empty((len(self.series_list[0].value),len(self.series_list)))
         headers=[]
         
-        if mode == 'value':
+        if axis == 'value':
             for i, ts in enumerate(self.series_list):
                 headers.append(ts.label)
                 vals[:,i]=ts.value
         
-        elif mode == 'time':
+        elif axis == 'time':
             for i, ts in enumerate(self.series_list):
                 headers.append(ts.label)
                 vals[:,i]=ts.time
         
         else:
-            raise ValueError('Mode should be either "time" or "value"')
+            raise ValueError('Axis should be either "time" or "value"')
         
         if labels == True:
             return vals, headers

--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -131,8 +131,8 @@ class EnsembleSeries(MultipleSeries):
 
     
 
-    def quantiles(self, qs=[0.05, 0.5, 0.95]):
-        '''Calculate quantiles of an EnsembleSeries object
+    def quantiles(self, qs=[0.05, 0.5, 0.95], mode = 'value'):
+        '''Calculate quantiles of an EnsembleSeries object. If mode is 'paleo', the calculation requires for the time axis to be the same. You can use the common_time method to do so. In essence, it transforms the time uncertainty into a y-axis uncertainty. If mode is 'chron', the values should be the same for all members of the emsemble. 
 
         Reuses [scipy.stats.mstats.mquantiles](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mstats.mquantiles.html) function.
 
@@ -142,6 +142,10 @@ class EnsembleSeries(MultipleSeries):
         qs : list, optional
 
             List of quantiles to consider for the calculation. The default is [0.05, 0.5, 0.95].
+        
+        mode : ['time', 'value']
+            
+            Whether to calculate the quantiles over the values or time. Default is 'value'. 
 
         Returns
         -------
@@ -149,6 +153,11 @@ class EnsembleSeries(MultipleSeries):
         ens_qs : EnsembleSeries
 
             EnsembleSeries object containing empirical quantiles of original 
+        
+        See also
+        --------
+        
+        pyleoclim.core.multipleseries.MultipleSeries.common_time : A method to align axes
 
         Examples
         --------
@@ -170,24 +179,68 @@ class EnsembleSeries(MultipleSeries):
             ts_ens = pyleo.EnsembleSeries(series_list)
 
             ens_qs = ts_ens.quantiles()
+            
+        To calculate in the time dimension:
+            
+        .. jupyter-execute::
+            
+            nn = 30 #number of age models
+            time = np.arange(1,20000,100) #create a time vector
+            std_dev = 20 # Noise to be considered
+            
+            t,v = pyleo.utils.gen_ts(model='colored_noise',nt=len(time),alpha=1.0)
+            
+            series_list = []
+            
+            for i in range(nn):
+                noise = np.random.normal(0,std_dev,len(time))
+                ts=pyleo.Series(time=np.sort(time+noise),value=v,verbose=False)
+                series_list.append(ts)
+            
+            time_ens = pyleo.EnsembleSeries(series_list)
+            
+            ens_qs = time_ens.quantiles(mode='time')            
 
         '''
-        time = np.copy(self.series_list[0].time)
-        vals = []
-        for ts in self.series_list:
-            if not np.array_equal(ts.time, time):
-                raise ValueError('Time axis not consistent across the ensemble!')
-
-            vals.append(ts.value)
-
-        vals = np.array(vals)
-        # ens_qs = mquantiles(vals, qs, axis=0)
-        ens_qs = np.nanquantile(vals, qs, axis=0)
-
-        ts_list = []
-        for i, quant in enumerate(ens_qs):
-            ts = Series(time=time, value=quant, label=f'{qs[i]*100:g}%', verbose=False)
-            ts_list.append(ts)
+        if mode == 'value':
+            time = np.copy(self.series_list[0].time)
+            vals = []
+            for ts in self.series_list:
+                if not np.array_equal(ts.time, time):
+                    raise ValueError('Time axis not consistent across the ensemble!')
+    
+                vals.append(ts.value)
+    
+            vals = np.array(vals)
+            # ens_qs = mquantiles(vals, qs, axis=0)
+            ens_qs = np.nanquantile(vals, qs, axis=0)
+    
+            ts_list = []
+            for i, quant in enumerate(ens_qs):
+                ts = Series(time=time, value=quant, label=f'{qs[i]*100:g}%', verbose=False)
+                ts_list.append(ts)
+        
+        elif mode == 'time':
+            
+            value = np.copy(self.series_list[0].value)
+            vals = []
+            for ts in self.series_list:
+                if not np.array_equal(ts.value, value):
+                    raise ValueError('Value axis not consistent across the ensemble!')
+                vals.append(ts.time)        
+            
+            vals = np.array(vals)
+                    
+            # ens_qs = mquantiles(vals, qs, axis=0)
+            ens_qs = np.nanquantile(vals, qs, axis=0)
+    
+            ts_list = []
+            for i, quant in enumerate(ens_qs):
+                ts = Series(time=quant, value=value, label=f'{qs[i]*100:g}%', verbose=False)
+                ts_list.append(ts)
+        
+        else:
+            raise ValueError("Mode should be either 'value' or 'time'")
 
         ens_qs = EnsembleSeries(series_list=ts_list)
 
@@ -999,3 +1052,144 @@ class EnsembleSeries(MultipleSeries):
             return fig, ax
         else:
             return ax
+
+    def to_dataframe(self, mode = 'value'):
+        '''
+        Export the ensemble as a Pandas DataFrame, with members of the ensemble as columns. The columns are labeled according to the label in the individual series or numbered if 'label' is None.
+        
+
+        Parameters
+        ----------
+        mode : str, ['time', 'value']
+            Whether the return the ensemble from value or time. each The default is 'value'.
+
+        Raises
+        ------
+        ValueError
+            Mode should be either 'time' or 'value'
+
+        Returns
+        -------
+        df : pandas.DataFrame
+            A Pandas DataFrame containing members of the ensemble as columns. 
+        
+        .. jupyter-execute::
+            
+            nn = 30 #number of age models
+            time = np.arange(1,20000,100) #create a time vector
+            std_dev = 20 # Noise to be considered
+            
+            t,v = pyleo.utils.gen_ts(model='colored_noise',nt=len(time),alpha=1.0)
+            
+            series_list = []
+            
+            for i in range(nn):
+                noise = np.random.normal(0,std_dev,len(time))
+                ts=pyleo.Series(time=np.sort(time+noise),value=v,verbose=False)
+                series_list.append(ts)
+            
+            time_ens = pyleo.EnsembleSeries(series_list)
+            ens_qs = time_ens.quantiles(mode='time')
+            
+            df=ens_qs.to_dataframe(mode='time')
+
+        '''
+        
+        df_dict = {}
+        idx = 0
+        
+        if mode == 'value':
+            for ts in self.series_list:
+                if ts.label is None:
+                    df_dict[idx]=ts.value
+                else:
+                    df_dict[ts.label]=ts.value
+                idx+=1
+        
+        elif mode == 'time':
+            for ts in self.series_list:
+                if ts.label is None:
+                    df_dict[idx]=ts.time
+                else:
+                    df_dict[ts.label]=ts.time
+                idx+=1
+        
+        else:
+            raise ValueError('Mode should be either "time" or "value"')
+            
+        df = pd.DataFrame(df_dict)
+        
+        return df
+    
+    def to_array(self, mode='value', labels=True):
+        '''
+        Returns an ensemble as a numpy array with an optional list for labels. Each column in the array corresponds to an ensemble member.
+
+        Parameters
+        ----------
+        mode : str, ['time', 'value'], optional
+            Whether the return the ensemble from value or time. The default is 'value'.
+        labels : bool, [True,False], optional
+            Whether to retrun a separate list with the timseries labels. The default is True.
+
+        Raises
+        ------
+        ValueError
+            Mode should be either 'time' or 'value'
+
+        Returns
+        -------
+        vals: numpy.array
+            An array where each column corresponds to an ensemble member
+            
+        headers: list
+            A list of corresponding labels for each columm
+            
+        Example
+        -------
+            
+        .. jupyter-execute::
+            
+            nn = 30 #number of age models
+            time = np.arange(1,20000,100) #create a time vector
+            std_dev = 20 # Noise to be considered
+            
+            t,v = pyleo.utils.gen_ts(model='colored_noise',nt=len(time),alpha=1.0)
+            
+            series_list = []
+            
+            for i in range(nn):
+                noise = np.random.normal(0,std_dev,len(time))
+                ts=pyleo.Series(time=np.sort(time+noise),value=v,verbose=False)
+                series_list.append(ts)
+            
+            time_ens = pyleo.EnsembleSeries(series_list)
+            ens_qs = time_ens.quantiles(mode='time')
+            
+            vals,headers=ens_qs.to_dataframe(mode='time')    
+
+        '''
+        
+        vals=np.empty((len(self.series_list[0].value),len(self.series_list)))
+        headers=[]
+        
+        if mode == 'value':
+            for i, ts in enumerate(self.series_list):
+                headers.append(ts.label)
+                vals[:,i]=ts.value
+        
+        elif mode == 'time':
+            for i, ts in enumerate(self.series_list):
+                headers.append(ts.label)
+                vals[:,i]=ts.time
+        
+        else:
+            raise ValueError('Mode should be either "time" or "value"')
+        
+        if labels == True:
+            return vals, headers
+        else:
+            return vals
+            
+        
+        

--- a/pyleoclim/tests/test_core_EnsembleSeries.py
+++ b/pyleoclim/tests/test_core_EnsembleSeries.py
@@ -246,11 +246,11 @@ class TestUIEnsembleSeriesQuantiles():
         
         time_ens = pyleo.EnsembleSeries(series_list)
         
-        ens_qs = time_ens.quantiles(mode='time') 
+        ens_qs = time_ens.quantiles(axis='time') 
         
 class TestUIEnsembleSeriesDataFrame():
-    @pytest.mark.parametrize('mode',['time','value'])
-    def test_to_dataframe_t0(self, mode):
+    @pytest.mark.parametrize('axis',['time','value'])
+    def test_to_dataframe_t0(self, axis):
         nn = 30 #number of age models
         time = np.arange(1,20000,100) #create a time vector
         std_dev = 20 # Noise to be considered
@@ -265,12 +265,12 @@ class TestUIEnsembleSeriesDataFrame():
             series_list.append(ts)
         
         time_ens = pyleo.EnsembleSeries(series_list)
-        ens_qs = time_ens.quantiles(mode='time')
+        ens_qs = time_ens.quantiles(axis='time')
         
-        if mode == 'time':        
-            df=ens_qs.to_dataframe(mode='time')
-        elif mode == 'value':
-            df=time_ens.to_dataframe(mode='value')
+        if axis == 'time':        
+            df=ens_qs.to_dataframe(axis='time')
+        elif axis == 'value':
+            df=time_ens.to_dataframe(axis='value')
 
 class TestUIEnsembleSeriesArray():
     
@@ -298,12 +298,12 @@ class TestUIEnsembleSeriesArray():
             series_list.append(ts)
         
         time_ens = pyleo.EnsembleSeries(series_list)
-        ens_qs = time_ens.quantiles(mode='time')
+        ens_qs = time_ens.quantiles(axis='time')
         
         if labels == True:
-            vals,headers=ens_qs.to_array(mode=mode) 
+            vals,headers=ens_qs.to_array(axis=mode) 
         else:
-            vals = ens_qs.to_array(mode=mode) 
+            vals = ens_qs.to_array(axis=mode) 
 
 # class TestUIEnsembleSeriesDistplot():
 #     def test_histplot_t0(self):

--- a/pyleoclim/tests/test_core_EnsembleSeries.py
+++ b/pyleoclim/tests/test_core_EnsembleSeries.py
@@ -211,6 +211,100 @@ class TestUIEnsembleSeriesHistplot():
         ts_ens.histplot()
         pyleo.closefig()
 
+class TestUIEnsembleSeriesQuantiles():
+    def test_quantiles_t0(self):
+        nn = 30 # number of noise realizations
+        nt = 500
+        series_list = []
+
+        t,v = pyleo.utils.gen_ts(model='colored_noise',nt=nt,alpha=1.0)
+        signal = pyleo.Series(t,v)
+
+        for idx in range(nn):  # noise
+            noise = np.random.randn(nt,nn)*100
+            ts = pyleo.Series(time=signal.time, value=signal.value+noise[:,idx], verbose=False)
+            series_list.append(ts)
+
+        ts_ens = pyleo.EnsembleSeries(series_list)
+
+        ens_qs = ts_ens.quantiles()
+    
+    def test_quantiles_t1(self):
+        
+        nn = 30 #number of age models
+        time = np.arange(1,20000,100) #create a time vector
+        std_dev = 20 # Noise to be considered
+        
+        t,v = pyleo.utils.gen_ts(model='colored_noise',nt=len(time),alpha=1.0)
+        
+        series_list = []
+        
+        for i in range(nn):
+            noise = np.random.normal(0,std_dev,len(time))
+            ts=pyleo.Series(time=np.sort(time+noise),value=v,verbose=False)
+            series_list.append(ts)
+        
+        time_ens = pyleo.EnsembleSeries(series_list)
+        
+        ens_qs = time_ens.quantiles(mode='time') 
+        
+class TestUIEnsembleSeriesDataFrame():
+    @pytest.mark.parametrize('mode',['time','value'])
+    def test_to_dataframe_t0(self, mode):
+        nn = 30 #number of age models
+        time = np.arange(1,20000,100) #create a time vector
+        std_dev = 20 # Noise to be considered
+        
+        t,v = pyleo.utils.gen_ts(model='colored_noise',nt=len(time),alpha=1.0)
+        
+        series_list = []
+        
+        for i in range(nn):
+            noise = np.random.normal(0,std_dev,len(time))
+            ts=pyleo.Series(time=np.sort(time+noise),value=v,verbose=False)
+            series_list.append(ts)
+        
+        time_ens = pyleo.EnsembleSeries(series_list)
+        ens_qs = time_ens.quantiles(mode='time')
+        
+        if mode == 'time':        
+            df=ens_qs.to_dataframe(mode='time')
+        elif mode == 'value':
+            df=time_ens.to_dataframe(mode='value')
+
+class TestUIEnsembleSeriesArray():
+    
+    @pytest.mark.parametrize(
+        ('labels', 'mode'),
+        [
+            (True,'time'),
+            (True,'value'),
+            (False,'time'),
+            (False,'value'),
+        ]
+    )
+    def test_to_array_t0(self,labels,mode):
+        nn = 30 #number of age models
+        time = np.arange(1,20000,100) #create a time vector
+        std_dev = 20 # Noise to be considered
+        
+        t,v = pyleo.utils.gen_ts(model='colored_noise',nt=len(time),alpha=1.0)
+        
+        series_list = []
+        
+        for i in range(nn):
+            noise = np.random.normal(0,std_dev,len(time))
+            ts=pyleo.Series(time=np.sort(time+noise),value=v,verbose=False)
+            series_list.append(ts)
+        
+        time_ens = pyleo.EnsembleSeries(series_list)
+        ens_qs = time_ens.quantiles(mode='time')
+        
+        if labels == True:
+            vals,headers=ens_qs.to_array(mode=mode) 
+        else:
+            vals = ens_qs.to_array(mode=mode) 
+
 # class TestUIEnsembleSeriesDistplot():
 #     def test_histplot_t0(self):
 #         '''Test for EnsembleSeries.distplot()


### PR DESCRIPTION
Add  functionality to calculate the quantiles on time instead of values. Also added capability to export an ensemble series to a pandas dataframe or numpy array. Useful to get the quantiles in a more analysis-ready format.

Added docstrings and tests for all functions (note: there was no test for quantiles) 