### PR TITLE
Fix for failing documentation on read the docs

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -4049,13 +4049,13 @@ class Series:
             multiplier = int(multiplier)
         unit = search.group(2)
         if unit.lower() in tsbase.MATCH_A:
-            rule = f'{multiplier}AS'
+            rule = f'{multiplier}YS'
         elif unit.lower() in tsbase.MATCH_KA:
-            rule = f'{1_000*multiplier}AS'
+            rule = f'{1_000*multiplier}YS'
         elif unit.lower() in tsbase.MATCH_MA:
-            rule = f'{1_000_000*multiplier}AS'
+            rule = f'{1_000_000*multiplier}YS'
         elif unit.lower() in tsbase.MATCH_GA:
-            rule = f'{1_000_000_000*multiplier}AS'
+            rule = f'{1_000_000_000*multiplier}YS'
 
         ser = self.to_pandas()
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description='A Python package for paleoclimate data analysis',
     long_description=read("README.md"),
     long_description_content_type = 'text/markdown',
-    author='Deborah Khider, Feng Zhu, Julien Emile-Geay, Jun Hu, Myron Kwan, Pratheek Athreya, Alexander James, Daniel Garijo',
+    author='Deborah Khider, Julien Emile-Geay, Feng Zhu, Jordan Landers, Alexander James, Jun Hu, Myron Kwan, Pratheek Athreya, Daniel Garijo',
     author_email='linkedearth@gmail.com',
     url='https://github.com/LinkedEarth/Pyleoclim_util/pyleoclim',
     download_url='https://github.com/LinkedEarth/Pyleoclim_util/tarball/'+version,
@@ -28,7 +28,7 @@ setup(
     classifiers=[],
     install_requires=[
         "LiPD==0.2.8.8",
-        "pandas>=2.0.0",
+        "pandas==2.1.4",
         "kneed>=0.7.0",
         "statsmodels>=0.13.2",
         "seaborn==0.12.2",


### PR DESCRIPTION
The documentation is failing on an example for the resample function. The bug is related to pandas and has been documented [here](https://github.com/pandas-dev/pandas/issues/57427). 

In the meantime, pinning to pandas v2.1.4 seems to fix the problem so I pinned Pyleoclim to this version until 2.2 is more stable and they fix all the problems related to non-nanosecond date time. 

Note that pandas will also deprecate `AS` for `YS` soon so this was corrected in the resample function for future compatibility. 