### PR TITLE
Include MLE estimation of tau_0 and sigma_2

### DIFF
--- a/pyleoclim/core/psds.py
+++ b/pyleoclim/core/psds.py
@@ -283,7 +283,7 @@ class PSD:
         if method not in ['ar1sim', 'ar1asym']:
                 raise ValueError("The available methods are 'ar1sim' and 'ar1asym'")
 
-        if method == 'ar1sim':
+        if method in ['ar1sim', 'uar1']:
             signif_scals = None
             if scalogram:
                 try:
@@ -359,7 +359,7 @@ class PSD:
                 s = PSD(frequency=self.frequency, amplitude = item, label=label)
                 ms_base.append(s)
                 new.signif_qs = MultiplePSD(ms_base)
-
+            
         return new
 
     def beta_est(self, fmin=None, fmax=None, logf_binning_step='max', verbose=False):

--- a/pyleoclim/core/psds.py
+++ b/pyleoclim/core/psds.py
@@ -283,7 +283,7 @@ class PSD:
         if method not in ['ar1sim', 'ar1asym']:
                 raise ValueError("The available methods are 'ar1sim' and 'ar1asym'")
 
-        if method in ['ar1sim', 'uar1']:
+        if method in ['ar1sim', 'ar1old']: # fix later in Series.surrogates()
             signif_scals = None
             if scalogram:
                 try:

--- a/pyleoclim/tests/test_utils_tsmodel.py
+++ b/pyleoclim/tests/test_utils_tsmodel.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Feb 26 10:36:37 2024
+
+@author: julieneg
+"""
+
+import pytest
+import numpy as np
+from pyleoclim.utils import tsmodel
+
+
+def test_ar1fit_ml_t0():
+    '''
+    Tests whether this method works well on an evenly-spaced AR(1) process
+
+    '''
+    tol = 1e-2
+    t,v = tsmodel.gen_ts(model='ar1',nt=200) # should have gamma close to 0.5
+    tau, sigma2 = tsmodel.ar1fit_ml(v,t)
+    
+    # tau should be close to np.log(2)
+    
+    assert np.abs(sigma2 - 1) < tol
+    assert np.abs(tau + np.log(2)) < tol
+    
+    
+    

--- a/pyleoclim/tests/test_utils_tsmodel.py
+++ b/pyleoclim/tests/test_utils_tsmodel.py
@@ -10,6 +10,29 @@ import pytest
 import numpy as np
 from pyleoclim.utils import tsmodel
 
+@pytest.mark.parametrize('model', ["exponential", "poisson"])
+def test_time_increments_0(model):
+    '''
+    Generate time increments with 1-parameter models
+    '''
+    delta_t = tsmodel.time_increments(n=20, param=1, delta_t_dist = model)
+    assert all(np.cumsum(delta_t)>0)
+
+def test_time_increments_1():
+    '''
+    Generate time increments with Pareto
+    '''
+    delta_t = tsmodel.time_increments(n=20, param=[4.2,2.5], delta_t_dist = "pareto")
+    assert all(np.cumsum(delta_t)>0)
+    
+def test_time_increments_2():
+    '''
+    Generate time increments with random choice
+    '''
+    delta_t = tsmodel.time_increments(n=20, delta_t_dist = "random_choice",
+                                      param=[[1,2],[.95,.05]] )
+    assert all(np.cumsum(delta_t)>0)
+
 @pytest.mark.parametrize('evenly_spaced', [True, False])
 def test_ar1fit_ml(evenly_spaced):
     '''
@@ -17,12 +40,13 @@ def test_ar1fit_ml(evenly_spaced):
 
     '''
     # define tolerance
-    tol = .2
+    tol = .4
     tau = 2
     sigma_2 = 1
     
     # create p=50 time series
-    y_sim, t_sim = tsmodel.ar1_sim_geneva(tau_0=tau, sigma_2_0=sigma_2, evenly_spaced=evenly_spaced, p = 10)
+    y_sim, t_sim = tsmodel.ar1_sim_geneva(n=200, tau_0=tau, sigma_2_0=sigma_2, 
+                                          evenly_spaced=evenly_spaced, p = 10)
 
     # Create an empty matrix to store estimated parameters
     theta_hat_matrix = np.empty((y_sim.shape[1], 2))

--- a/pyleoclim/tests/test_utils_tsmodel.py
+++ b/pyleoclim/tests/test_utils_tsmodel.py
@@ -16,15 +16,26 @@ def test_ar1fit_ml(evenly_spaced):
     Tests whether this method works well on an AR(1) process with known parameters
 
     '''
+    # define tolerance
     tol = .3
     
-    y, t, t_delta  = tsmodel.ar1_sim_geneva(evenly_spaced=evenly_spaced)
-    theta_hat = tsmodel.ar1_fit_ml(y, t)
+    # create p=50 time series
+    y_sim, t_sim = tsmodel.ar1_sim_geneva(evenly_spaced=evenly_spaced, p = 100)
+
+    # Create an empty matrix to store estimated parameters
+    theta_hat_matrix = np.empty((y_sim.shape[1], 2))
+    
+    # estimate parameters for each time series
+    for j in range(y_sim.shape[1]):
+        theta_hat_matrix[j,:]  = tsmodel.ar1_fit_ml(y_sim[:, j], t_sim[:, j])
+    
+    # compute mean of estimated param for each simulate ts
+    theta_hat_bar = np.mean(theta_hat_matrix, axis=0)
     
     # test that 
     
-    assert np.abs(theta_hat[0]-5) < tol
-    assert np.abs(theta_hat[1]-2) < tol
+    assert np.abs(theta_hat_bar[0]-5) < tol
+    assert np.abs(theta_hat_bar[1]-2) < tol
     
     
 

--- a/pyleoclim/tests/test_utils_tsmodel.py
+++ b/pyleoclim/tests/test_utils_tsmodel.py
@@ -8,64 +8,10 @@ Created on Mon Feb 26 10:36:37 2024
 
 import pytest
 import numpy as np
-import pyleoclim.utils.tsmodel
 from pyleoclim.utils import tsmodel
 
-# for MLE estimation of tau_0
-from scipy import optimize
-from scipy.optimize import minimize
-
-#@Julien, I initially deifned these function in ts.model.py, however, the test didnt's pass as the defined function where not found when running the test, hence, I defined all functions in the test file
-
-def tau_estimation(y, t):
-    '''
-    @Julien I had to redefine this function in the test to ensure the test is working when running pytest pyleoclim/tests/test_utils_tsmodel.py
-
-    Estimates the  temporal decay scale of an (un)evenly spaced time series.
-
-    Esimtates the temporal decay scale of an (un)evenly spaced time series. 
-    Uses `scipy.optimize.minimize_scalar <https://docs.scipy.org/doc/scipy/reference/optimize.minimize_scalar-bounded.html>`_.
-
-    Parameters
-    ----------
-
-    y : array
-        A time series
-    t : array
-        Time axis of the time series
-
-    Returns
-    -------
-
-    tau_est : float
-        The estimated persistence
-
-    References
-    ----------
-
-    Mudelsee, M. TAUEST: A Computer Program for Estimating Persistence in Unevenly Spaced Weather/Climate Time Series.
-        Comput. Geosci. 28, 69–72 (2002).
-
-    '''
-    #  pd_y = preprocess(y, t, detrend=detrend, params=params, gaussianize=gaussianize, standardize=standardize)
-    dt = np.diff(t)
-    #  assert dt > 0, "The time point should be increasing!"
-
-    def ar1_fun(a):
-        #  return np.sum((pd_y[1:] - pd_y[:-1]*a**dt)**2)
-        return np.sum((y[1:] - y[:-1]*a**dt)**2)
-
-    a_est = optimize.minimize_scalar(ar1_fun, bounds=[0, 1], method='bounded').x
-    #  a_est = optimize.minimize_scalar(ar1_fun, method='brent').x
-
-    tau_est = -1 / np.log(a_est)
-
-    return tau_est
-
-
-def gen_evenly_unevenly_spaced_ar1(n, tau_0, sigma_2_0, seed=12345, scale_parameter_delta_t = None, evenly_spaced = False):
+def gen_evenly_unevenly_spaced_ar1(n=200, tau_0=5, sigma_2_0=2, seed=123, scale_parameter_delta_t=1, evenly_spaced = False):
   """
-  @Julien, I just added this way of generating a evenly/unevenly spaced AR1 so I can use it on the test both evenly and not evenly spaced AR1, plan is to remove it later and use your generation function
   
   Generate a time series of length n from an autoregressive process of order 1 with evenly/unevenly spaced time points.
   In case parameter evenly_spaced is True, delta_t  (spacing between time points) is a vector of 1, if evenly_spaced is False, delta_t are generated from an exponential distribution.
@@ -104,78 +50,16 @@ def gen_evenly_unevenly_spaced_ar1(n, tau_0, sigma_2_0, seed=12345, scale_parame
     y[i] = phi_i * y[i-1] + sigma_i * z[i]
   return y, t, t_delta
 
-
-
-
-def n_ll_unevenly_spaced_ar1(theta, y, t):
-  """
-    Compute the negative log-likelihood of an evenly/unevenly spaced AR1 model.
-    It is assumed that the vector theta is initialized with log of tau and log of sigma 2.
-      
-    Args:
-        theta: A vector of length 2, with the first value being the log of tau_0, and the second value the log of sigma^2.
-        y: The vector of observations.
-        t: the vector of time value.
-  
-    Returns:
-      A double. The value of the negative log likelihood evalued with the arguments provided (theta, y, t).
-  """
-  # define n
-  n = len(y)
-  log_tau_0 = theta[0]
-  log_sigma_2_0 = theta[1]
-  tau_0 = np.exp(log_tau_0)
-  sigma_2 = np.exp(log_sigma_2_0)
-  delta = np.diff(t)
-  phi = np.exp((-delta / tau_0))
-  term_1 =  y[1:n] - (phi * y[0:(n-1)])
-  term_2 = pow(term_1, 2)
-  term_3 = term_2 / (1- pow(phi, 2))
-  term_4 = 1/(sigma_2 * n) *sum(term_3)
-  term_5 = 1/n * sum(np.log(1-pow(phi,2)))
-  nll = np.log(2*np.pi) + np.log(sigma_2) + term_5 + term_4
-  return(nll)
-
-
-
-def ar1fit_ml(y, t):
+@pytest.mark.parametrize('evenly_spaced', [True, False])
+def test_ar1fit_ml(evenly_spaced):
     '''
-   Estimate parameters tau_0 and sigma_2_0 based on the MLE
-
-    Parameters
-    ----------
-    y : An array of the values of the time series
-        Values of the times series.
-    t : An array of the time index values of the time series
-        Time index values of the time series
-
-    Returns:
-        An array containing the estimated parameters tau_0_hat and sigma_2_hat, first entry is tau_0_hat, second entry is sigma_2_hat
-    -------
-    None.
+    Tests whether this method works well on an AR(1) process with known parameters
 
     '''
-    # obtain initial value for tau_0
-    tau_initial_value = tau_estimation(y= y, t = t)
-    # obtain initial value for sifma_2_0
-    sigma_2_initial_value = np.var(y)
-    # obtain MLE 
-    optim_res = minimize(n_ll_unevenly_spaced_ar1, x0=[np.log(tau_initial_value), np.log(sigma_2_initial_value)], args=(y,t), method='nelder-mead', options={'xatol': 1e-10, 'disp': False, 'maxiter': 1000})
-    # transform back parameters
-    theta_hat = np.exp(optim_res.x)
+    tol = .3
     
-    return theta_hat
-
-
-def test_ar1fit_ml_evenly_spaced():
-    '''
-    Tests whether this method works well on an evenly-spaced AR(1) process
-
-    '''
-    tol = .5
-    
-    y, t, t_delta  = gen_evenly_unevenly_spaced_ar1(n = 200, tau_0=5, sigma_2_0=2, seed=123, scale_parameter_delta_t=1, evenly_spaced=True)
-    theta_hat = ar1fit_ml(y, t)
+    y, t, t_delta  = gen_evenly_unevenly_spaced_ar1(evenly_spaced=evenly_spaced)
+    theta_hat = tsmodel.ar1_fit_ml(y, t)
     
     # test that 
     
@@ -184,18 +68,5 @@ def test_ar1fit_ml_evenly_spaced():
     
     
 
-def test_ar1fit_ml_unevenly_spaced():
-    '''
-    Tests whether this method works well on an unevenly-spaced AR(1) process
 
-    '''
-    tol = .5
-    
-    y, t, t_delta  = gen_evenly_unevenly_spaced_ar1(n = 200, tau_0=5, sigma_2_0=2, seed=123, scale_parameter_delta_t=1, evenly_spaced=False)
-    theta_hat = ar1fit_ml(y, t)
-    
-    # test that 
-    
-    assert np.abs(theta_hat[0]-5) < tol
-    assert np.abs(theta_hat[1]-2) < tol
     

--- a/pyleoclim/tests/test_utils_tsmodel.py
+++ b/pyleoclim/tests/test_utils_tsmodel.py
@@ -8,26 +8,194 @@ Created on Mon Feb 26 10:36:37 2024
 
 import pytest
 import numpy as np
+import pyleoclim.utils.tsmodel
 from pyleoclim.utils import tsmodel
 
+# for MLE estimation of tau_0
+from scipy import optimize
+from scipy.optimize import minimize
 
-def uneven_ar1(nt =100):  # define your function here
+#@Julien, I initially deifned these function in ts.model.py, however, the test didnt's pass as the defined function where not found when running the test, hence, I defined all functions in the test file
 
-    return t, v
+def tau_estimation(y, t):
+    '''
+    @Julien I had to redefine this function in the test to ensure the test is working when running pytest pyleoclim/tests/test_utils_tsmodel.py
 
-def test_ar1fit_ml_t0():
+    Estimates the  temporal decay scale of an (un)evenly spaced time series.
+
+    Esimtates the temporal decay scale of an (un)evenly spaced time series. 
+    Uses `scipy.optimize.minimize_scalar <https://docs.scipy.org/doc/scipy/reference/optimize.minimize_scalar-bounded.html>`_.
+
+    Parameters
+    ----------
+
+    y : array
+        A time series
+    t : array
+        Time axis of the time series
+
+    Returns
+    -------
+
+    tau_est : float
+        The estimated persistence
+
+    References
+    ----------
+
+    Mudelsee, M. TAUEST: A Computer Program for Estimating Persistence in Unevenly Spaced Weather/Climate Time Series.
+        Comput. Geosci. 28, 69–72 (2002).
+
+    '''
+    #  pd_y = preprocess(y, t, detrend=detrend, params=params, gaussianize=gaussianize, standardize=standardize)
+    dt = np.diff(t)
+    #  assert dt > 0, "The time point should be increasing!"
+
+    def ar1_fun(a):
+        #  return np.sum((pd_y[1:] - pd_y[:-1]*a**dt)**2)
+        return np.sum((y[1:] - y[:-1]*a**dt)**2)
+
+    a_est = optimize.minimize_scalar(ar1_fun, bounds=[0, 1], method='bounded').x
+    #  a_est = optimize.minimize_scalar(ar1_fun, method='brent').x
+
+    tau_est = -1 / np.log(a_est)
+
+    return tau_est
+
+
+def gen_evenly_unevenly_spaced_ar1(n, tau_0, sigma_2_0, seed=12345, scale_parameter_delta_t = None, evenly_spaced = False):
+  """
+  @Julien, I just added this way of generating a evenly/unevenly spaced AR1 so I can use it on the test both evenly and not evenly spaced AR1, plan is to remove it later and use your generation function
+  
+  Generate a time series of length n from an autoregressive process of order 1 with evenly/unevenly spaced time points.
+  In case parameter evenly_spaced is True, delta_t  (spacing between time points) is a vector of 1, if evenly_spaced is False, delta_t are generated from an exponential distribution.
+  Args:
+    n: An integer. The length of the time series, 
+    tau_0: Parameter of the unevenly AR1 model.
+    sigma_0: Parameter of the unevenly AR1 model.
+    seed: An integer. Random seed for reproducible results.
+    scale_parameter_delta_t: parameter of the exponential distribution for generating the delta_t.
+  
+  Returns: A tuple with three array, the y value, the index t and the delta_t of the generated time series.
+  
+  """
+  # generate delta-t depending on the parameter evenly_spaced
+  if evenly_spaced:
+      t_delta = [1]*n
+  else:
+      np.random.seed(seed)
+      # consider generation of the delta_t from an exponential distribution
+      t_delta= np.random.exponential(scale = scale_parameter_delta_t, size=n)
+  # obtain the time index from the delta_t distribution
+  t = np.cumsum(t_delta)
+    
+  # create empty vector
+  y = np.empty(n)
+  
+  # generate unevenly spaced AR1
+  np.random.seed(seed)
+  z = np.random.normal(loc=0, scale=1, size=n)
+  y[0] = z[0]
+  for i in range(1,n):
+    delta_i = t[i] - t[i-1] 
+    phi_i = np.exp(-delta_i / tau_0)
+    sigma_2_i = sigma_2_0 * (1-pow(phi_i, 2))
+    sigma_i = np.sqrt(sigma_2_i)
+    y[i] = phi_i * y[i-1] + sigma_i * z[i]
+  return y, t, t_delta
+
+
+
+
+def n_ll_unevenly_spaced_ar1(theta, y, t):
+  """
+    Compute the negative log-likelihood of an evenly/unevenly spaced AR1 model.
+    It is assumed that the vector theta is initialized with log of tau and log of sigma 2.
+      
+    Args:
+        theta: A vector of length 2, with the first value being the log of tau_0, and the second value the log of sigma^2.
+        y: The vector of observations.
+        t: the vector of time value.
+  
+    Returns:
+      A double. The value of the negative log likelihood evalued with the arguments provided (theta, y, t).
+  """
+  # define n
+  n = len(y)
+  log_tau_0 = theta[0]
+  log_sigma_2_0 = theta[1]
+  tau_0 = np.exp(log_tau_0)
+  sigma_2 = np.exp(log_sigma_2_0)
+  delta = np.diff(t)
+  phi = np.exp((-delta / tau_0))
+  term_1 =  y[1:n] - (phi * y[0:(n-1)])
+  term_2 = pow(term_1, 2)
+  term_3 = term_2 / (1- pow(phi, 2))
+  term_4 = 1/(sigma_2 * n) *sum(term_3)
+  term_5 = 1/n * sum(np.log(1-pow(phi,2)))
+  nll = np.log(2*np.pi) + np.log(sigma_2) + term_5 + term_4
+  return(nll)
+
+
+
+def ar1fit_ml(y, t):
+    '''
+   Estimate parameters tau_0 and sigma_2_0 based on the MLE
+
+    Parameters
+    ----------
+    y : An array of the values of the time series
+        Values of the times series.
+    t : An array of the time index values of the time series
+        Time index values of the time series
+
+    Returns:
+        An array containing the estimated parameters tau_0_hat and sigma_2_hat, first entry is tau_0_hat, second entry is sigma_2_hat
+    -------
+    None.
+
+    '''
+    # obtain initial value for tau_0
+    tau_initial_value = tau_estimation(y= y, t = t)
+    # obtain initial value for sifma_2_0
+    sigma_2_initial_value = np.var(y)
+    # obtain MLE 
+    optim_res = minimize(n_ll_unevenly_spaced_ar1, x0=[np.log(tau_initial_value), np.log(sigma_2_initial_value)], args=(y,t), method='nelder-mead', options={'xatol': 1e-10, 'disp': False, 'maxiter': 1000})
+    # transform back parameters
+    theta_hat = np.exp(optim_res.x)
+    
+    return theta_hat
+
+
+def test_ar1fit_ml_evenly_spaced():
     '''
     Tests whether this method works well on an evenly-spaced AR(1) process
 
     '''
-    tol = 1e-2
-    t,v = tsmodel.gen_ts(model='ar1',nt=200) # should have gamma close to 0.5
-    tau, sigma2 = tsmodel.ar1fit_ml(v,t)
+    tol = .5
     
-    # tau should be close to np.log(2)
+    y, t, t_delta  = gen_evenly_unevenly_spaced_ar1(n = 200, tau_0=5, sigma_2_0=2, seed=123, scale_parameter_delta_t=1, evenly_spaced=True)
+    theta_hat = ar1fit_ml(y, t)
     
-    assert np.abs(sigma2 - 1) < tol
-    assert np.abs(tau + np.log(2)) < tol
+    # test that 
+    
+    assert np.abs(theta_hat[0]-5) < tol
+    assert np.abs(theta_hat[1]-2) < tol
     
     
+
+def test_ar1fit_ml_unevenly_spaced():
+    '''
+    Tests whether this method works well on an unevenly-spaced AR(1) process
+
+    '''
+    tol = .5
+    
+    y, t, t_delta  = gen_evenly_unevenly_spaced_ar1(n = 200, tau_0=5, sigma_2_0=2, seed=123, scale_parameter_delta_t=1, evenly_spaced=False)
+    theta_hat = ar1fit_ml(y, t)
+    
+    # test that 
+    
+    assert np.abs(theta_hat[0]-5) < tol
+    assert np.abs(theta_hat[1]-2) < tol
     

--- a/pyleoclim/tests/test_utils_tsmodel.py
+++ b/pyleoclim/tests/test_utils_tsmodel.py
@@ -11,6 +11,10 @@ import numpy as np
 from pyleoclim.utils import tsmodel
 
 
+def uneven_ar1(nt =100):  # define your function here
+
+    return t, v
+
 def test_ar1fit_ml_t0():
     '''
     Tests whether this method works well on an evenly-spaced AR(1) process

--- a/pyleoclim/tests/test_utils_tsmodel.py
+++ b/pyleoclim/tests/test_utils_tsmodel.py
@@ -10,46 +10,6 @@ import pytest
 import numpy as np
 from pyleoclim.utils import tsmodel
 
-def gen_evenly_unevenly_spaced_ar1(n=200, tau_0=5, sigma_2_0=2, seed=123, scale_parameter_delta_t=1, evenly_spaced = False):
-  """
-  
-  Generate a time series of length n from an autoregressive process of order 1 with evenly/unevenly spaced time points.
-  In case parameter evenly_spaced is True, delta_t  (spacing between time points) is a vector of 1, if evenly_spaced is False, delta_t are generated from an exponential distribution.
-  Args:
-    n: An integer. The length of the time series, 
-    tau_0: Parameter of the unevenly AR1 model.
-    sigma_0: Parameter of the unevenly AR1 model.
-    seed: An integer. Random seed for reproducible results.
-    scale_parameter_delta_t: parameter of the exponential distribution for generating the delta_t.
-  
-  Returns: A tuple with three array, the y value, the index t and the delta_t of the generated time series.
-  
-  """
-  # generate delta-t depending on the parameter evenly_spaced
-  if evenly_spaced:
-      t_delta = [1]*n
-  else:
-      np.random.seed(seed)
-      # consider generation of the delta_t from an exponential distribution
-      t_delta= np.random.exponential(scale = scale_parameter_delta_t, size=n)
-  # obtain the time index from the delta_t distribution
-  t = np.cumsum(t_delta)
-    
-  # create empty vector
-  y = np.empty(n)
-  
-  # generate unevenly spaced AR1
-  np.random.seed(seed)
-  z = np.random.normal(loc=0, scale=1, size=n)
-  y[0] = z[0]
-  for i in range(1,n):
-    delta_i = t[i] - t[i-1] 
-    phi_i = np.exp(-delta_i / tau_0)
-    sigma_2_i = sigma_2_0 * (1-pow(phi_i, 2))
-    sigma_i = np.sqrt(sigma_2_i)
-    y[i] = phi_i * y[i-1] + sigma_i * z[i]
-  return y, t, t_delta
-
 @pytest.mark.parametrize('evenly_spaced', [True, False])
 def test_ar1fit_ml(evenly_spaced):
     '''
@@ -58,7 +18,7 @@ def test_ar1fit_ml(evenly_spaced):
     '''
     tol = .3
     
-    y, t, t_delta  = gen_evenly_unevenly_spaced_ar1(evenly_spaced=evenly_spaced)
+    y, t, t_delta  = tsmodel.ar1_sim_geneva(evenly_spaced=evenly_spaced)
     theta_hat = tsmodel.ar1_fit_ml(y, t)
     
     # test that 

--- a/pyleoclim/tests/test_utils_tsmodel.py
+++ b/pyleoclim/tests/test_utils_tsmodel.py
@@ -17,10 +17,12 @@ def test_ar1fit_ml(evenly_spaced):
 
     '''
     # define tolerance
-    tol = .3
+    tol = .2
+    tau = 2
+    sigma_2 = 1
     
     # create p=50 time series
-    y_sim, t_sim = tsmodel.ar1_sim_geneva(evenly_spaced=evenly_spaced, p = 100)
+    y_sim, t_sim = tsmodel.ar1_sim_geneva(tau_0=tau, sigma_2_0=sigma_2, evenly_spaced=evenly_spaced, p = 10)
 
     # Create an empty matrix to store estimated parameters
     theta_hat_matrix = np.empty((y_sim.shape[1], 2))
@@ -34,8 +36,8 @@ def test_ar1fit_ml(evenly_spaced):
     
     # test that 
     
-    assert np.abs(theta_hat_bar[0]-5) < tol
-    assert np.abs(theta_hat_bar[1]-2) < tol
+    assert np.abs(theta_hat_bar[0]-tau) < tol
+    assert np.abs(theta_hat_bar[1]-sigma_2) < tol
     
     
 

--- a/pyleoclim/utils/tsmodel.py
+++ b/pyleoclim/utils/tsmodel.py
@@ -21,6 +21,10 @@ __all__ = [
     'gen_ts'
 ]
 
+
+# for MLE estimation of tau_0
+from scipy.optimize import minimize
+
 def ar1_model(t, tau, output_sigma=1):
     ''' Simulate AR(1) process with REDFIT
     
@@ -97,26 +101,10 @@ def ar1_fit(y, t=None):
 
     return g
 
-def ar1fit_ml(y, t=None):
-    '''
-    Does the same thing as ar1_fit, but BETTER
 
-    Parameters
-    ----------
-    y : TYPE
-        DESCRIPTION.
-    t : TYPE, optional
-        DESCRIPTION. The default is None.
 
-    Returns
-    -------
-    None.
 
-    '''
-    
-    #TODO: COPY YOUR CODE HERE
-    
-    return tau, sigma2
+
 
 def ar1_sim(y, p, t=None):
     '''Simulate AR(1) process(es) with sample autocorrelation value

--- a/pyleoclim/utils/tsmodel.py
+++ b/pyleoclim/utils/tsmodel.py
@@ -104,47 +104,71 @@ def ar1_fit(y, t=None):
 
 
 
-def ar1_sim_geneva(n=200, tau_0=5, sigma_2_0=2, seed=123, p=1, delta_t_dist = "exponential", scale_exp_delta_t=1, lambda_poisson_delta_t= 1, scale_pareto_delta_t = 1, shape_pareto_delta_t=1, value_random_choice=[1,2], prob_random_choice=[.95,.05], evenly_spaced = False):
+def ar1_sim_geneva(n=200, tau_0=5, sigma_2_0=2, seed=123, p=1, 
+                   evenly_spaced = False, delta_t_dist = "exponential", 
+                   scale_exp_delta_t=1, lambda_poisson_delta_t= 1, 
+                   scale_pareto_delta_t = 1, shape_pareto_delta_t=1, 
+                   value_random_choice=[1,2], prob_random_choice=[.95,.05]):
   """
   Generate a time series of length n from an autoregressive process of order 1 with evenly/unevenly spaced time points.
-  In case parameter evenly_spaced is True, delta_t  (spacing between time points) is a vector of 1, 
-  if evenly_spaced is False, delta_t can be generated from various distribution (exponential, pareto, poisson and random choice).
   
   Parameters
   ----------
-  n: integer. 
-      The length of the time series, 
+  n: integer
+      The length of the time series 
+      
   tau_0: float
-      Parameter of the unevenly AR1 model.
-  sigma_0: float
-      Parameter of the unevenly AR1 model.
+      Time decay parameter of the  AR(1) model ($\phi = e^{-\tau}$)
+      
+  sigma_2_0: float
+      Variance of the innovations 
+      
   seed: integer
       Random seed for reproducible results.
+      
   p: integer
       Parameter specifying the number of time series to generate
-  delta_t_dist: string
-                parameter specifying the distribution that generate the delta_t
+      
+  evenly_spaced: boolean     
+      if True, delta_t  (spacing between time points) is a vector of 1, 
+      if False, delta_t is generated from various distribution (exponential, pareto, poisson and random choice).  
+      
+  delta_t_dist: str
+      the distribution that generates the delta_t
+      possible choices include 'exponential', 'poisson', 'pareto', or 'random_choice'
+      
   scale_exp_delta_t: float
-                     Scale parameter for the exponential distribution
+      Scale parameter for the exponential distribution
+      
   lambda_poisson_delta_t: float
-                       parameter for the Poisson distribution                   
+      parameter for the Poisson distribution    
+               
   scale_pareto_delta_t: float 
-                        Scale parameter for the Pareto distribution, see https://numpy.org/doc/stable/reference/random/generated/numpy.random.pareto.html
+      Scale parameter for the Pareto distribution, see https://numpy.org/doc/stable/reference/random/generated/numpy.random.pareto.html
+      
   shape_pareto_delta_t: float 
-                        Shape parameter for the Pareto distribution, see https://numpy.org/doc/stable/reference/random/generated/numpy.random.pareto.html
-  value_random_choice: 1-D array-like 
-                       elements from which the random sample is generated 
-  prob_random_choice= 1-D array-like 
-                      probabilities associated with each entry value_random_choice
+      Shape parameter for the Pareto distribution, see https://numpy.org/doc/stable/reference/random/generated/numpy.random.pareto.html
+      
+  value_random_choice: 2-list 
+      elements from which the random sample is generated # PLEASE EXPLAIN
+      
+  prob_random_choice: 2-list 
+      probabilities associated with each entry value_random_choice # PLEASE EXPLAIN                   
+       
 
   Returns
   -------
   A tuple of 2 arrays  
-    y_sim : array
-    n by p matrix of simulated AR(1) vector
-    t_sim : array
-    n by p matrix of t vector
-  
+    y_sim : n x p NumPy array 
+        matrix of simulated AR(1) vectors
+    t_sim : n x p NumPy array 
+        matrix of corresponding time axes
+        
+  See also
+  --------
+
+  pyleoclim.utils.tsmodel.ar1_fit_ml : Maximumum likelihood estimate of AR(1) parameters 
+      
   """
   
   # checks
@@ -189,7 +213,7 @@ def ar1_sim_geneva(n=200, tau_0=5, sigma_2_0=2, seed=123, p=1, delta_t_dist = "e
               t_delta = np.random.choice(value_random_choice, size=n, p=prob_random_choice)
       
       # obtain the time index from the delta_t distribution
-      t = np.cumsum(t_delta)
+      t = np.cumsum(t_delta)-1
         
       # create empty vector
       y = np.empty(n)

--- a/pyleoclim/utils/tsmodel.py
+++ b/pyleoclim/utils/tsmodel.py
@@ -97,6 +97,27 @@ def ar1_fit(y, t=None):
 
     return g
 
+def ar1fit_ml(y, t=None):
+    '''
+    Does the same thing as ar1_fit, but BETTER
+
+    Parameters
+    ----------
+    y : TYPE
+        DESCRIPTION.
+    t : TYPE, optional
+        DESCRIPTION. The default is None.
+
+    Returns
+    -------
+    None.
+
+    '''
+    
+    #TODO: COPY YOUR CODE HERE
+    
+    return tau, sigma2
+
 def ar1_sim(y, p, t=None):
     '''Simulate AR(1) process(es) with sample autocorrelation value
 
@@ -403,7 +424,7 @@ def gen_ts(model, t=None, nt=1000, **kwargs):
         
         - colored_noise : colored noise with one scaling slope
         - colored_noise_2regimes : colored noise with two regimes of two different scaling slopes
-        - ar1 : AR(1) series
+        - ar1 : AR(1) series, with default autocorrelation of 0.5
 
     t : array
         the time axis
@@ -447,7 +468,6 @@ def gen_ts(model, t=None, nt=1000, **kwargs):
     tsm_args[model].update(kwargs)
 
     v = tsm[model](t=t, **tsm_args[model])
-    #ts = Series(time=t, value=v)
 
     return t, v
 

--- a/pyleoclim/utils/tsmodel.py
+++ b/pyleoclim/utils/tsmodel.py
@@ -17,7 +17,7 @@ __all__ = [
     'ar1_fit',
     'ar1_fit_ml',
     'ar1_sim',
-    'ar1_sim_frankenstein',
+    'ar1_sim_geneva',
     'colored_noise',
     'colored_noise_2regimes',
     'gen_ar1_evenly',

--- a/pyleoclim/utils/tsmodel.py
+++ b/pyleoclim/utils/tsmodel.py
@@ -612,7 +612,7 @@ def ar1_sim_geneva(n, tau_0=5, sigma_2_0=2, seed=123, p=1,  evenly_spaced = Fals
 
 def time_increments(n, param, delta_t_dist = "exponential", seed = 12345):
     '''
-    Generate time increment vector according to a specific probability model
+    Generate a time increment vector according to a specific probability model
 
     Parameters
     ----------
@@ -623,24 +623,23 @@ def time_increments(n, param, delta_t_dist = "exponential", seed = 12345):
         Random seed for reproducible results.
         
     delta_t_dist: str
-        the distribution that generates the delta_t
+        the probability distribution of delta_t
         possible choices include 'exponential', 'poisson', 'pareto', or 'random_choice'
         
         if 'exponential', `param` is expected to be a single scale parameter (traditionally denoted \lambda)
         if 'poisson', `param` is expected to be a single parameter (rate)
-        if 'pareto', expects a 2-list with the shape & scale parameters (in that order)
-        if 'random_choice', expects a 2-list containing the arrays:
-            
-            value_random_choice: ?
-                elements from which the random sample is generated # PLEASE EXPLAIN
-                
-            prob_random_choice: ?
-                probabilities associated with each entry value_random_choice # PLEASE EXPLAIN           
+        if 'pareto', expects a 2-list with 2 scalar shape & scale parameters (in that order)
+        if 'random_choice', expects a 2-list containing the arrays:      
+            value_random_choice: 
+                elements from which the random sample is generated (e.g. [1,2])
+            prob_random_choice: 
+                probabilities associated with each entry value_random_choice  (e.g. [.95,.05])
+            (These two arrays must be of the same size)
         
     Returns:
     -------
     
-    delta_t : n-array of time increments
+    delta_t : 1D array of time increments, length n
 
     '''
     # check for a valid distribution 


### PR DESCRIPTION
- Added fcts ar1_sim_geneva(), n_ll_unevenly_spaced_ar1() and ar1fit_m()l in file tsmodel.py
- Created 2 tests to ensure MLE estimation works fine with evenly and unevenly spaced AR1.
- Added time_increments() to tsmodel.py, together with tests
- eventually, the surrogate method `ar1sim` will point to ar1_sim_geneva(), and the current one will be relabeled `ar1old` for benchmarking purposes. 
- For now functionalities are unaccessible from the user API ; waiting on #228 to be completed (in stages)