### PR TITLE
Generalized surrogates

### DIFF
--- a/pyleoclim/core/__init__.py
+++ b/pyleoclim/core/__init__.py
@@ -9,8 +9,8 @@ from .geoseries import GeoSeries
 from .psds import PSD, MultiplePSD
 from .multipleseries import MultipleSeries
 from .multiplegeoseries import MultipleGeoSeries
-#from .surrogateseries import SurrogateSeries
-from .ensembleseries import EnsembleSeries, SurrogateSeries
+from .surrogateseries import SurrogateSeries
+from .ensembleseries import EnsembleSeries
 from .scalograms import Scalogram, MultipleScalogram
 from .coherence import Coherence
 from .corr import Corr

--- a/pyleoclim/core/__init__.py
+++ b/pyleoclim/core/__init__.py
@@ -9,8 +9,8 @@ from .geoseries import GeoSeries
 from .psds import PSD, MultiplePSD
 from .multipleseries import MultipleSeries
 from .multiplegeoseries import MultipleGeoSeries
-from .surrogateseries import SurrogateSeries
-from .ensembleseries import EnsembleSeries
+#from .surrogateseries import SurrogateSeries
+from .ensembleseries import EnsembleSeries, SurrogateSeries
 from .scalograms import Scalogram, MultipleScalogram
 from .coherence import Coherence
 from .corr import Corr

--- a/pyleoclim/core/coherence.py
+++ b/pyleoclim/core/coherence.py
@@ -706,6 +706,8 @@ class Coherence:
         surr2 = self.timeseries2.surrogates(
             number=number, seed=seed, method=method, settings=settings
         )
+        
+        # adjust time axis
 
         wtcs, xwts = [], []
 

--- a/pyleoclim/core/coherence.py
+++ b/pyleoclim/core/coherence.py
@@ -664,6 +664,13 @@ class Coherence:
 
             coh_sig2 = coh.signif_test(number=100, qs=[.9,.95,.99])
             coh_sig2.plot()
+            
+        One can also specifiy a different method to obtain surrogates, e.g. phase randomization:
+            
+        .. jupyter-execute::
+
+            coh_sig3 = coh.signif_test(method='phaseran')
+            coh_sig3.plot()    
 
         The plot() function will represent the 95% level as contours by default.
         If you need to show 99%, say, use the `signif_thresh` argument:
@@ -685,6 +692,7 @@ class Coherence:
         (pseudo)random number at every execution, which may be important for marginal features
         in small ensembles. In general, however, we recommend increasing the
         number of draws to check that features are robust.
+        
 
         '''
 

--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -247,7 +247,8 @@ class EnsembleSeries(MultipleSeries):
 
         return ens_qs
 
-    def correlation(self, target=None, timespan=None, alpha=0.05, settings=None, fdr_kwargs=None, common_time_kwargs=None, mute_pbar=False, seed=None):
+    def correlation(self, target=None, timespan=None, alpha=0.05, method = 'ttest',
+                    settings=None, fdr_kwargs=None, common_time_kwargs=None, mute_pbar=False, seed=None):
         ''' Calculate the correlation between an EnsembleSeries object to a target.
 
         If the target is not specified, then the 1st member of the ensemble will be the target
@@ -272,6 +273,9 @@ class EnsembleSeries(MultipleSeries):
         alpha : float
 
             The significance level (0.05 by default)
+       
+        method : str, {'ttest','ar1sim','phaseran'}
+            method for significance testing. Default is 'ttest'
 
         settings : dict
 
@@ -366,7 +370,7 @@ class EnsembleSeries(MultipleSeries):
                 value2 = target.value
                 time2 = target.time
 
-            ts2 = Series(time=time2, value=value2, verbose=idx==0)
+            ts2 = Series(time=time2, value=value2, verbose=idx==0, auto_time_params=False)
             corr_res = ts1.correlation(ts2, timespan=timespan, settings=settings, common_time_kwargs=common_time_kwargs, seed=seed)
             r_list.append(corr_res.r)
             signif_list.append(corr_res.signif)

--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -371,7 +371,9 @@ class EnsembleSeries(MultipleSeries):
                 time2 = target.time
 
             ts2 = Series(time=time2, value=value2, verbose=idx==0, auto_time_params=False)
-            corr_res = ts1.correlation(ts2, timespan=timespan, settings=settings, common_time_kwargs=common_time_kwargs, seed=seed)
+            corr_res = ts1.correlation(ts2, timespan=timespan, method=method, 
+                                       settings=settings, mute_pbar=True,
+                                       common_time_kwargs=common_time_kwargs, seed=seed)
             r_list.append(corr_res.r)
             signif_list.append(corr_res.signif)
             p_list.append(corr_res.p)

--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -3,6 +3,7 @@ The EnsembleSeries class is a child of MultipleSeries, designed for ensemble app
 In addition to a MultipleSeries object, an EnsembleSeries object has the following properties:
 - All series members are assumed to share the same units and other metadata.
 - The class enables ensemble-oriented methods for computation (e.g., quantiles) and visualization (e.g., envelope plot).    
+
 """
 
 from ..utils import plotting
@@ -1193,5 +1194,4 @@ class EnsembleSeries(MultipleSeries):
         else:
             return vals
             
-        
         

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -58,7 +58,7 @@ class MultipleSeries:
         soi = pyleo.utils.load_dataset('SOI')
         nino = pyleo.utils.load_dataset('NINO3')
         ms = soi & nino
-        ms.name = 'ENSO'
+        ms.label = 'ENSO'
         ms
                 
     '''

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -1627,13 +1627,10 @@ class MultipleSeries:
 
         .. jupyter-execute::
 
-            import pyleoclim as pyleo
-            url = 'http://wiki.linked.earth/wiki/index.php/Special:WTLiPD?op=export&lipdid=MD982176.Stott.2004'
-            data = pyleo.Lipd(usr_path = url)
-            tslist = data.to_LipdSeriesList()
-            tslist = tslist[2:] # drop the first two series which only concerns age and depth
-            ms = pyleo.MultipleSeries(tslist)
-
+            soi = pyleo.utils.load_dataset('SOI')
+            nino = pyleo.utils.load_dataset('NINO3')
+            ms = soi & nino
+            ms.name = 'ENSO'
             fig, ax = ms.plot()
 
         '''

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3634,26 +3634,43 @@ class Series:
 
         '''
         settings = {} if settings is None else settings.copy()
-        surrogate_func = {
-            'ar1sim': tsmodel.ar1_sim,
-            'phaseran': tsutils.phaseran
-        }
+        # surrogate_func = {
+        #     'ar1sim': tsmodel.ar1_sim,
+        #     'phaseran': tsutils.phaseran
+        # }
         args = {}
-        args['ar1sim'] = {'t': self.time}
+        time = self.time
+        args['ar1sim'] = {'t': time}
+        args['phaseran'] = {}
         args[method].update(settings)
 
         if seed is not None:
             np.random.seed(seed)
 
-        surr_res = surrogate_func[method](self.value, number, **args[method])
+        if method == 'ar1sim':
+            surr_res = tsmodel.ar1_sim(self.value, number, **args[method])
+        elif method == 'phaseran':
+            surr_res = tsmodel.ar1_sim(self.value, number, **args[method])
+            #if len(time) % 2 == 0:
+            #    time = time[0:-1]
+        # elif method == 'ar1_ml':
+        #     # TODO : implement Lionel's ML method
+        # elif method == 'power-law':
+        #     # TODO : implement Stochastic
+        # elif method == 'fBm':
+        #      # TODO : implement Stochastic
+            
+        #surr_res = surrogate_func[method](self.value, number, **args[method])
         # TODO: extract parameters for parametric methods
         
         if len(np.shape(surr_res)) == 1:
             surr_res = surr_res[:, np.newaxis]
 
         s_list = []
-        for i,s in enumerate(surr_res.T):
-            s_tmp = Series(time=self.time, value=s,  # will need reformation after ar1fit_ml pull
+        for i, s in enumerate(surr_res.T):
+            print(len(s),len(time))
+                
+            s_tmp = Series(time=time, value=s,  # will need reformation after ar1fit_ml pull
                            time_name=self.time_name,  
                            time_unit=self.time_unit, 
                            value_name=self.value_name, 
@@ -3663,7 +3680,7 @@ class Series:
             s_list.append(s_tmp)
 
         surr = SurrogateSeries(series_list=s_list, 
-                               name = self.label,
+                               label = self.label,
                                surrogate_method=method, 
                                surrogate_args=args[method])
 

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3636,10 +3636,6 @@ class Series:
 
         '''
         settings = {} if settings is None else settings.copy()
-        # surrogate_func = {
-        #     'ar1sim': tsmodel.ar1_sim,
-        #     'phaseran': tsutils.phaseran
-        # }
         args = {}
         time = self.time
         args['ar1sim'] = {'t': time}
@@ -3655,16 +3651,13 @@ class Series:
             surr_res = tsutils.phaseran(self.value, number, **args[method])
             if len(time) % 2 == 0:
                 time = time[0:-1]
-        # elif method == 'ar1sim_geneva':
+        # elif method == 'uar1':
         #     # TODO : implement Lionel's ML method
         # elif method == 'power-law':
         #     # TODO : implement Stochastic
         # elif method == 'fBm':
         #      # TODO : implement Stochastic
-            
-        #surr_res = surrogate_func[method](self.value, number, **args[method])
-        # TODO: extract parameters for parametric methods
-        
+                    
         if len(np.shape(surr_res)) == 1:
             surr_res = surr_res[:, np.newaxis]
 

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3648,9 +3648,7 @@ class Series:
         if method == 'ar1sim':
             surr_res = tsmodel.ar1_sim(self.value, number, **args[method])
         elif method == 'phaseran':
-            surr_res = tsutils.phaseran(self.value, number, **args[method])
-            if len(time) % 2 == 0:
-                time = time[0:-1]
+            surr_res = tsutils.phaseran2(self.value, number, **args[method])
         # elif method == 'uar1':
         #     # TODO : implement Lionel's ML method
         # elif method == 'power-law':
@@ -3663,8 +3661,7 @@ class Series:
 
         s_list = []
         for i, s in enumerate(surr_res.T):
-                
-            s_tmp = Series(time=time, value=s,  # will need reformation after ar1fit_ml pull
+            s_tmp = Series(time=time, value=s,  # will need reformation after uar1 pull
                            time_name=self.time_name,  
                            time_unit=self.time_unit, 
                            value_name=self.value_name, 

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3666,7 +3666,7 @@ class Series:
                            time_unit=self.time_unit, 
                            value_name=self.value_name, 
                            value_unit=self.value_unit, 
-                           label = self.label + " surrogate " + str(i),
+                           label = str(self.label or '') + " surr #" + str(i+1),
                            verbose=False, auto_time_params=True)
             s_list.append(s_tmp)
 

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3349,7 +3349,7 @@ class Series:
 
         return coh
 
-    def correlation(self, target_series, timespan=None, alpha=0.05, statistic = 'pearsonr',
+    def correlation(self, target_series, alpha=0.05, method = 'phaseran', timespan=None,  
                     settings=None, common_time_kwargs=None, seed=None):
         ''' Estimates the correlation and its associated significance between two time series (not ncessarily IID).
 
@@ -3369,18 +3369,20 @@ class Series:
 
         target_series : Series
             A pyleoclim Series object
-
+        
+        alpha : float
+            The significance level (default: 0.05)
+        
+        method : str, {'ttest','ar1sim','phaseran'}
+            method for significance testing. Default is 'phaseran'
+        
         timespan : tuple
             The time interval over which to perform the calculation
             
-        statistic : str
+        statistic : str  [UNDER CONSTRUCTION]
             statistic being evaluated. Can use any of the SciPy-supported ones:
                 https://docs.scipy.org/doc/scipy/reference/stats.html#association-correlation-tests
             Default: 'pearsonr'        
-        
-
-        alpha : float
-            The significance level (default: 0.05)
 
         settings : dict
             Parameters for the correlation function, including:
@@ -3451,7 +3453,7 @@ class Series:
         '''
 
         settings = {} if settings is None else settings.copy()
-        corr_args = {'alpha': alpha}
+        corr_args = {'alpha': alpha, 'method': method}
         corr_args.update(settings)
 
         ms = MultipleSeries([self, target_series])
@@ -3475,9 +3477,9 @@ class Series:
         if seed is not None:
             np.random.seed(seed)
 
-        if corr_args.method == 'ttest':
-            (r, signif, p) = corrutils.corr_ttest(ts0.value, ts1.value, alpha=alpha)
-        else:  
+        if method == 'ttest':
+            corr_res = corrutils.corr_ttest(ts0.value, ts1.value, alpha=alpha)
+        elif method == 'tte':  
             number = corr_args['nsim'] if 'nsim' in corr_args.keys() else 1000
             seed = corr_args['seed'] if 'seed' in corr_args.keys() else None
             method = corr_args['method'] if 'method' in corr_args.keys() else None

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -8,7 +8,6 @@ How to create and manipulate such objects is described in a short example below,
 """
 
 import datetime as dt
-#import operator
 import re
 
 from ..utils import tsutils, plotting, tsmodel, tsbase, lipdutils, jsonutils
@@ -30,11 +29,9 @@ from ..core.resolution import Resolution
 
 import seaborn as sns
 import matplotlib.pyplot as plt
-#import matplotlib as mpl # could also from matplotlib.colors import ColorbarBase
 import numpy as np
 import pandas as pd
 
-#from tabulate import tabulate
 from collections import namedtuple
 from copy import deepcopy
 import matplotlib.colors as mcolors
@@ -3650,9 +3647,9 @@ class Series:
         if method == 'ar1sim':
             surr_res = tsmodel.ar1_sim(self.value, number, **args[method])
         elif method == 'phaseran':
-            surr_res = tsmodel.ar1_sim(self.value, number, **args[method])
-            #if len(time) % 2 == 0:
-            #    time = time[0:-1]
+            surr_res = tsutils.phaseran(self.value, number, **args[method])
+            if len(time) % 2 == 0:
+                time = time[0:-1]
         # elif method == 'ar1_ml':
         #     # TODO : implement Lionel's ML method
         # elif method == 'power-law':
@@ -3668,7 +3665,6 @@ class Series:
 
         s_list = []
         for i, s in enumerate(surr_res.T):
-            print(len(s),len(time))
                 
             s_tmp = Series(time=time, value=s,  # will need reformation after ar1fit_ml pull
                            time_name=self.time_name,  

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3490,10 +3490,11 @@ class Series:
                                                  method=method, settings=surr_settings)
             ts1_surr = ts1.timeseries.surrogates(number=number, seed=seed, 
                                                  method=method, settings=surr_settings)
-            for i in range(number)
+            #for i in range(number):
             
+                # do something
 
-        #corr_res = corrutils.corr_sig(value1, value2, **corr_args)
+            #corr_res = corrutils.corr_sig(value1, value2, **corr_args)
         signif = True if corr_res['signif'] == 1 else False
         corr = Corr(corr_res['r'], corr_res['p'], signif, alpha)
 
@@ -3606,7 +3607,7 @@ class Series:
         Parameters
         ----------
 
-        method : {ar1sim}
+        method : {ar1sim, phaseran}
             Uses an AR1 model to generate surrogates of the timeseries
 
         number : int
@@ -3645,15 +3646,26 @@ class Series:
             np.random.seed(seed)
 
         surr_res = surrogate_func[method](self.value, number, **args[method])
+        # TODO: extract parameters for parametric methods
+        
         if len(np.shape(surr_res)) == 1:
             surr_res = surr_res[:, np.newaxis]
 
         s_list = []
-        for s in surr_res.T:
-            s_tmp = Series(time=self.time, value=s, time_name=self.time_name, time_unit=self.time_unit, value_name=self.value_name, value_unit=self.value_unit, verbose=False)
+        for i,s in enumerate(surr_res.T):
+            s_tmp = Series(time=self.time, value=s,  # will need reformation after ar1fit_ml pull
+                           time_name=self.time_name,  
+                           time_unit=self.time_unit, 
+                           value_name=self.value_name, 
+                           value_unit=self.value_unit, 
+                           label = self.label + " surrogate " + str(i),
+                           verbose=False, auto_time_params=True)
             s_list.append(s_tmp)
 
-        surr = SurrogateSeries(series_list=s_list, surrogate_method=method, surrogate_args=args[method])
+        surr = SurrogateSeries(series_list=s_list, 
+                               name = self.label,
+                               surrogate_method=method, 
+                               surrogate_args=args[method])
 
         return surr
 

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3605,7 +3605,10 @@ class Series:
         ----------
 
         method : {ar1sim, phaseran}
-            Uses an AR1 model to generate surrogates of the timeseries
+            The method used to generate surrogates of the timeseries
+            
+            Note that phaseran assumes an odd number of samples. If the series 
+            has even length, the last point is dropped to satisfy this requirement
 
         number : int
             The number of surrogates to generate
@@ -3650,7 +3653,7 @@ class Series:
             surr_res = tsutils.phaseran(self.value, number, **args[method])
             if len(time) % 2 == 0:
                 time = time[0:-1]
-        # elif method == 'ar1_ml':
+        # elif method == 'ar1sim_geneva':
         #     # TODO : implement Lionel's ML method
         # elif method == 'power-law':
         #     # TODO : implement Stochastic

--- a/pyleoclim/core/surrogateseries.py
+++ b/pyleoclim/core/surrogateseries.py
@@ -6,6 +6,8 @@ SurrogateSeries is a child of MultipleSeries, designed for Monte Carlo tests
 
 from ..core.multipleseries import MultipleSeries
 
+SUPPORTED_SURROGATES = frozenset(['ar1sim','phaseran']) # broadcast all supported surrogates as global variable, for exception handling
+
 class SurrogateSeries(MultipleSeries):
     ''' Object containing surrogate timeseries, usually obtained through recursive modeling (e.g., AR(1))
 

--- a/pyleoclim/core/surrogateseries.py
+++ b/pyleoclim/core/surrogateseries.py
@@ -19,9 +19,9 @@ class SurrogateSeries(MultipleSeries):
         
         # refine the display name
         if surrogate_method == 'ar1sim':
-            self.label = label + " surrogates [AR(1)]"
+            self.label = str(label or "series") + " surrogates [AR(1)]"
         elif surrogate_method == 'phaseran':
-            self.label = label + " surrogates [phase-randomized]"
+            self.label = str(label or "series") + " surrogates [phase-randomized]"
         else:
             raise ValueError('Surrogate method should either be "ar1sim" or "phaseran"')
         

--- a/pyleoclim/core/surrogateseries.py
+++ b/pyleoclim/core/surrogateseries.py
@@ -6,7 +6,7 @@ SurrogateSeries is a child of MultipleSeries, designed for Monte Carlo tests
 
 from ..core.multipleseries import MultipleSeries
 
-SUPPORTED_SURROGATES = frozenset(['ar1sim','phaseran']) # broadcast all supported surrogates as global variable, for exception handling
+supported_surrogates = frozenset(['ar1sim','phaseran']) # broadcast all supported surrogates as global variable, for exception handling
 
 class SurrogateSeries(MultipleSeries):
     ''' Object containing surrogate timeseries, usually obtained through recursive modeling (e.g., AR(1))

--- a/pyleoclim/core/surrogateseries.py
+++ b/pyleoclim/core/surrogateseries.py
@@ -5,13 +5,12 @@ SurrogateSeries is a child of MultipleSeries, designed for Monte Carlo tests
 """
 
 from ..core.multipleseries import MultipleSeries
-#from ..core.ensembleseries import EnsembleSeries
 
 class SurrogateSeries(MultipleSeries):
     ''' Object containing surrogate timeseries, usually obtained through recursive modeling (e.g., AR(1))
 
     Surrogate Series is a child of MultipleSeries. All methods available for MultipleSeries are available for surrogate series.
-    EnsembleSeries would be a more logical choice
+    EnsembleSeries would be a more logical choice, but it creates circular imports that break the package. 
     '''
     def __init__(self, series_list, label, surrogate_method=None, surrogate_args=None): 
         self.series_list = series_list

--- a/pyleoclim/core/surrogateseries.py
+++ b/pyleoclim/core/surrogateseries.py
@@ -20,9 +20,9 @@ class SurrogateSeries(MultipleSeries):
         
         # refine the display name
         if surrogate_method == 'ar1sim':
-            self.label = self.label + " surrogates [AR(1)]"
+            self.label = label + " surrogates [AR(1)]"
         elif surrogate_method == 'phaseran':
-            self.label = self.label + " surrogates [phase-randomized]"
+            self.label = label + " surrogates [phase-randomized]"
         else:
             raise ValueError('Surrogate method should either be "ar1sim" or "phaseran"')
         

--- a/pyleoclim/core/surrogateseries.py
+++ b/pyleoclim/core/surrogateseries.py
@@ -5,13 +5,27 @@ SurrogateSeries is a child of MultipleSeries, designed for Monte Carlo tests
 """
 
 from ..core.multipleseries import MultipleSeries
+#from ..core.ensembleseries import EnsembleSeries
 
 class SurrogateSeries(MultipleSeries):
     ''' Object containing surrogate timeseries, usually obtained through recursive modeling (e.g., AR(1))
 
     Surrogate Series is a child of MultipleSeries. All methods available for MultipleSeries are available for surrogate series.
+    EnsembleSeries would be a more logical choice
     '''
-    def __init__(self, series_list, surrogate_method=None, surrogate_args=None): 
+    def __init__(self, series_list, label, surrogate_method=None, surrogate_args=None): 
         self.series_list = series_list
         self.surrogate_method = surrogate_method
         self.surrogate_args = surrogate_args
+        
+        # refine the display name
+        if surrogate_method == 'ar1sim':
+            self.label = self.label + " surrogates [AR(1)]"
+        elif surrogate_method == 'phaseran':
+            self.label = self.label + " surrogates [phase-randomized]"
+        else:
+            raise ValueError('Surrogate method should either be "ar1sim" or "phaseran"')
+        
+         
+       
+        

--- a/pyleoclim/tests/conftest.py
+++ b/pyleoclim/tests/conftest.py
@@ -38,7 +38,7 @@ def metadata():
 def gen_ts():
     """ Generate realistic-ish Series for testing """
     t,v = pyleo.utils.gen_ts(model='colored_noise',nt=50)
-    ts = pyleo.Series(t,v, verbose=False)
+    ts = pyleo.Series(t,v, verbose=False, auto_time_params=True)
     return ts
 
 @pytest.fixture
@@ -47,7 +47,7 @@ def unevenly_spaced_series():
     length = 10
     t = np.linspace(1,length,length) ** 2
     v = np.ones(length)
-    series = pyleo.Series(time=t, value =v, verbose=False)
+    series = pyleo.Series(time=t, value =v, verbose=False, auto_time_params=True)
     return series
 
 @pytest.fixture

--- a/pyleoclim/tests/test_core_Coherence.py
+++ b/pyleoclim/tests/test_core_Coherence.py
@@ -31,15 +31,16 @@ class TestUiCoherencePlot:
         coh = ts2.wavelet_coherence(ts1)
         fig,ax = coh.plot()
         pyleo.closefig(fig)
-    
-    def test_plot_t1(self, gen_ts):
+        
+    @pytest.mark.parametrize('method', ['ar1sim','phaseran'])
+    def test_plot_t1(self, gen_ts, method):
         ''' Test Coherence.plot WTC with significance
         '''
         ts1 = gen_ts
         ts2 = gen_ts
         coh = ts2.wavelet_coherence(ts1)
         
-        coh_signif = coh.signif_test(number=10,qs = [0.8, 0.9, .95])
+        coh_signif = coh.signif_test(number=10, method=method, qs = [0.8, 0.9, .95])
         fig,ax = coh_signif.plot(signif_thresh=0.99)
         pyleo.closefig(fig)
         

--- a/pyleoclim/tests/test_core_EnsembleSeries.py
+++ b/pyleoclim/tests/test_core_EnsembleSeries.py
@@ -21,7 +21,6 @@ import pytest
 
 import pyleoclim as pyleo
 from pyleoclim.utils.tsmodel import (
-    ar1_sim,
     colored_noise,
 )
 
@@ -31,7 +30,7 @@ def gen_ts(model, nt, alpha):
     'wrapper for gen_ts in pyleoclim'
 
     t, v = pyleo.utils.gen_ts(model=model, nt=nt, alpha=alpha)
-    ts = pyleo.Series(t, v)
+    ts = pyleo.Series(t, v, verbose=False, auto_time_params=True)
     return ts
 
 
@@ -59,9 +58,9 @@ class TestUIEnsembleSeriesCorrelation():
         t0, v0 = gen_colored_noise(nt=nt)
         t0, noise = gen_normal(nt=nt)
 
-        ts0 = pyleo.Series(time=t0, value=v0)
-        ts1 = pyleo.Series(time=t0, value=v0+noise)
-        ts2 = pyleo.Series(time=t0, value=v0+2*noise)
+        ts0 = pyleo.Series(time=t0, value=v0, verbose=False, auto_time_params=True)
+        ts1 = pyleo.Series(time=t0, value=v0+noise, verbose=False, auto_time_params=True)
+        ts2 = pyleo.Series(time=t0, value=v0+2*noise, verbose=False, auto_time_params=True)
 
         ts_list = [ts1, ts2]
 
@@ -70,7 +69,7 @@ class TestUIEnsembleSeriesCorrelation():
         corr_res = ts_ens.correlation(ts0)
         signif_list = corr_res.signif
         for signif in signif_list:
-            assert signif is True
+            assert signif == True
 
 
     def test_correlation_t1(self):
@@ -80,10 +79,10 @@ class TestUIEnsembleSeriesCorrelation():
         t0, v0 = gen_colored_noise(nt=nt)
         t0, noise = gen_normal(nt=nt)
 
-        ts0 = pyleo.Series(time=t0, value=v0)
-        ts1 = pyleo.Series(time=t0, value=v0+noise)
-        ts2 = pyleo.Series(time=t0, value=v0+2*noise)
-        ts3 = pyleo.Series(time=t0, value=v0+1/2*noise)
+        ts0 = pyleo.Series(time=t0, value=v0, verbose=False, auto_time_params=True)
+        ts1 = pyleo.Series(time=t0, value=v0+noise, verbose=False, auto_time_params=True)
+        ts2 = pyleo.Series(time=t0, value=v0+2*noise, verbose=False, auto_time_params=True)
+        ts3 = pyleo.Series(time=t0, value=v0+1/2*noise, verbose=False, auto_time_params=True)
 
         ts_list1 = [ts0, ts1]
         ts_list2 = [ts2, ts3]
@@ -94,7 +93,7 @@ class TestUIEnsembleSeriesCorrelation():
         corr_res = ts_ens.correlation(ts_target)
         signif_list = corr_res.signif
         for signif in signif_list:
-            assert signif is True
+            assert signif == True
 
         assert np.size(corr_res.p) == np.size(ts_list1)
 
@@ -106,11 +105,11 @@ class TestUIEnsembleSeriesCorrelation():
         t0, v0 = gen_colored_noise(nt=nt)
         t0, noise = gen_normal(nt=nt)
 
-        ts0 = pyleo.Series(time=t0, value=v0)
-        ts1 = pyleo.Series(time=t0, value=v0+noise)
-        ts2 = pyleo.Series(time=t0, value=v0+2*noise)
-        ts3 = pyleo.Series(time=t0, value=v0+1/2*noise)
-        ts4 = pyleo.Series(time=t0, value=v0+3/2*noise)
+        ts0 = pyleo.Series(time=t0, value=v0, verbose=False, auto_time_params=True)
+        ts1 = pyleo.Series(time=t0, value=v0+noise, verbose=False, auto_time_params=True)
+        ts2 = pyleo.Series(time=t0, value=v0+2*noise, verbose=False, auto_time_params=True)
+        ts3 = pyleo.Series(time=t0, value=v0+1/2*noise, verbose=False, auto_time_params=True)
+        ts4 = pyleo.Series(time=t0, value=v0+3/2*noise, verbose=False, auto_time_params=True)
 
         ts_list1 = [ts0, ts1, ts4]
         ts_list2 = [ts2, ts3]
@@ -121,7 +120,7 @@ class TestUIEnsembleSeriesCorrelation():
         corr_res = ts_ens.correlation(ts_target)
         signif_list = corr_res.signif
         for signif in signif_list:
-            assert signif is True
+            assert signif == True
 
         assert np.size(corr_res.p) == np.size(ts_list1)
 
@@ -133,11 +132,11 @@ class TestUIEnsembleSeriesCorrelation():
         t0, v0 = gen_colored_noise(nt=nt)
         t0, noise = gen_normal(nt=nt)
 
-        ts0 = pyleo.Series(time=t0, value=v0)
-        ts1 = pyleo.Series(time=t0, value=v0+noise)
-        ts2 = pyleo.Series(time=t0, value=v0+2*noise)
-        ts3 = pyleo.Series(time=t0, value=v0+1/2*noise)
-        ts4 = pyleo.Series(time=t0, value=v0+3/2*noise)
+        ts0 = pyleo.Series(time=t0, value=v0, verbose=False, auto_time_params=True)
+        ts1 = pyleo.Series(time=t0, value=v0+noise, verbose=False, auto_time_params=True)
+        ts2 = pyleo.Series(time=t0, value=v0+2*noise, verbose=False, auto_time_params=True)
+        ts3 = pyleo.Series(time=t0, value=v0+1/2*noise, verbose=False, auto_time_params=True)
+        ts4 = pyleo.Series(time=t0, value=v0+3/2*noise, verbose=False, auto_time_params=True)
 
         ts_list1 = [ts0, ts1]
         ts_list2 = [ts2, ts3, ts4]
@@ -148,9 +147,31 @@ class TestUIEnsembleSeriesCorrelation():
         corr_res = ts_ens.correlation(ts_target)
         signif_list = corr_res.signif
         for signif in signif_list:
-            assert signif is True
+            assert signif == True
 
         assert np.size(corr_res.p) == np.size(ts_list1)
+        
+    @pytest.mark.parametrize('corr_method', ['ttest','built-in','ar1sim','phaseran'])
+    def test_correlation_t4(self,corr_method):
+        '''Test for EnsembleSeries.correlation() when the target is a Series
+           Test that all allowable methods are passed.  
+        '''
+        nt = 100
+        t0, v0 = gen_colored_noise(nt=nt)
+        t0, noise = gen_normal(nt=nt)
+
+        ts0 = pyleo.Series(time=t0, value=v0, verbose=False, auto_time_params=True)
+        ts1 = pyleo.Series(time=t0, value=v0+noise, verbose=False, auto_time_params=True)
+        ts2 = pyleo.Series(time=t0, value=v0+2*noise, verbose=False, auto_time_params=True)
+
+        ts_list = [ts1, ts2]
+
+        ts_ens = pyleo.EnsembleSeries(ts_list)
+
+        corr_res = ts_ens.correlation(ts0, method=corr_method)
+        signif_list = corr_res.signif
+        for signif in signif_list:
+            assert signif == True
 
     def test_plot_envelope_t0(self):
         ''' Test EnsembleSeries.plot_envelope() on a list of colored noise

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -610,8 +610,8 @@ class TestUISeriesCorrelation:
         v1 = ts.value + np.random.normal(loc=0, scale=1, size=nt)
         v2 = ts.value + np.random.normal(loc=0, scale=2, size=nt)
 
-        ts1 = pyleo.Series(time=ts.time, value=v1)
-        ts2 = pyleo.Series(time=ts.time, value=v2)
+        ts1 = pyleo.Series(time=ts.time, value=v1, verbose=False, auto_time_params=True)
+        ts2 = pyleo.Series(time=ts.time, value=v2, verbose=False, auto_time_params=True)
 
         corr_res = ts1.correlation(ts2, settings={'method': corr_method})
         r = corr_res.r

--- a/pyleoclim/utils/causality.py
+++ b/pyleoclim/utils/causality.py
@@ -12,8 +12,8 @@ __all__ = [
 import numpy as np
 from statsmodels.tsa.stattools import grangercausalitytests
 from tqdm import tqdm
-from .tsmodel import ar1_fit_evenly
-from .correlation import sm_ar1_sim, phaseran
+from .tsmodel import ar1_fit_evenly, sm_ar1_sim
+from .tsutils import phaseran
 from scipy.stats.mstats import mquantiles
 
 #-------

--- a/pyleoclim/utils/correlation.py
+++ b/pyleoclim/utils/correlation.py
@@ -7,6 +7,7 @@ Relevant functions for correlation analysis
 __all__ = [
     'corr_sig',
     'fdr',
+    'association'
 ]
 
 import numpy as np
@@ -674,33 +675,37 @@ def cov_shrink_rblw(S, n):
 
 def association(y1, y2, statistic='pearsonr',settings=None):
     '''
-    
+    Quantify the strength of a relationship (e.g. linear) between paired observations y1 and y2.
 
     Parameters
     ----------
     y1 : array, length n
-        DESCRIPTION.
-    y2 : TYPE
-        DESCRIPTION.
-    statistic : TYPE, optional
-        DESCRIPTION. The default is 'pearsonr'.
-    settings : TYPE, optional
-        DESCRIPTION. The default is None.
+        vector of (real) numbers of same length as y2, no NaNs allowed  
+    y2 : array, length n
+        vector of (real) numbers of same length as y1, no NaNs allowed
+    statistic : str, optional
+        The statistic used to measure the association, to be chosen from
+        https://docs.scipy.org/doc/scipy/reference/stats.html#association-correlation-tests
+        The default is 'pearsonr'.
+    settings : dict, optional
+        optional arguments to modify the behavior of the SciPy association functions
 
     Raises
     ------
     ValueError
-        DESCRIPTION.
+        Complains loudly if the requested statistic is not from the list above. 
 
     Returns
     -------
-    res : TYPE
-        DESCRIPTION.
-
+    res : instance result class
+        structure containing the result. The first element (res[0]) is always the statistic.
     '''
+    y1 = np.array(y1, dtype=float)
+    y2 = np.array(y2, dtype=float)
+    assert np.size(y1) == np.size(y2), 'The size of y1 and y2 should be the same'
+    
     args = {} if settings is None else settings.copy()
     acceptable_methods = ['pearsonr','spearmanr','kendalltau']
-    # https://docs.scipy.org/doc/scipy/reference/stats.html#association-correlation-tests
     if statistic in acceptable_methods:
         func = getattr(stats, statistic) 
         res = func(y1,y2,**args)

--- a/pyleoclim/utils/correlation.py
+++ b/pyleoclim/utils/correlation.py
@@ -84,9 +84,11 @@ def corr_sig(y1, y2, nsim=1000, method='isospectral', alpha=0.05):
     if method == 'ttest':
         (r, signif, p) = corr_ttest(y1, y2, alpha=alpha)
     elif method == 'isopersistent':
-        (r, signif, p) = corr_isopersist(y1, y2, alpha=alpha, nsim=nsim)
+        
+        #(r, signif, p) = corr_isopersist(y1, y2, alpha=alpha, nsim=nsim)
     elif method == 'isospectral':
         (r, signif, p) = corr_isospec(y1, y2, alpha=alpha, nsim=nsim)
+        
         
     # apply this syntax:
     # wave_res = wave_func[method](self.value, self.time, **args[method])
@@ -323,41 +325,6 @@ def corr_isopersist(y1, y2, alpha=0.05, nsim=1000):
 
     return r, signif, pval
 
-
-
-# def red_noise(N, M, g):
-#     ''' Produce M realizations of an AR1 process of length N with lag-1 autocorrelation g
-
-#     Parameters
-#     ----------
-
-#     N : int
-#         row dimensions
-        
-#     M : int
-#         column dimensions
-        
-#     g : float
-#         lag-1 autocorrelation coefficient
-
-#     Returns
-#     -------
-
-#     red : numpy array
-#         N rows by M columns matrix of an AR1 process
-
-#     Notes
-#     -----
-
-#     (Some Rights Reserved) Hepta Technologies, 2008
-#     J.E.G., GaTech, Oct 20th 2008
-#     '''
-#     red = np.zeros(shape=(N, M))
-#     red[0, :] = np.random.randn(1, M)
-#     for i in np.arange(1, N):
-#         red[i, :] = g * red[i-1, :] + np.random.randn(1, M)
-
-#     return red
 
 def corr_isospec(y1, y2, alpha=0.05, nsim=1000):
     ''' Estimates the significance of the correlation using phase randomization

--- a/pyleoclim/utils/correlation.py
+++ b/pyleoclim/utils/correlation.py
@@ -85,7 +85,7 @@ def corr_sig(y1, y2, nsim=1000, method='isospectral', alpha=0.05):
         (r, signif, p) = corr_ttest(y1, y2, alpha=alpha)
     elif method == 'isopersistent':
         
-        #(r, signif, p) = corr_isopersist(y1, y2, alpha=alpha, nsim=nsim)
+        (r, signif, p) = corr_isopersist(y1, y2, alpha=alpha, nsim=nsim)
     elif method == 'isospectral':
         (r, signif, p) = corr_isospec(y1, y2, alpha=alpha, nsim=nsim)
         

--- a/pyleoclim/utils/tsutils.py
+++ b/pyleoclim/utils/tsutils.py
@@ -16,19 +16,19 @@ __all__ = [
     'detrend',
     'detect_outliers_DBSCAN',
     'detect_outliers_kmeans',
-    'remove_outliers'
+    'remove_outliers',
+    'phaseran'
 ]
 
 import numpy as np
-from numpy import pi
 import pandas as pd
 import warnings
 import copy
 from scipy import special
 from scipy import signal
 from scipy import interpolate
-from scipy.interpolate import splrep, splev
 from scipy import stats
+from pyhht import EMD
 from sklearn.neighbors import NearestNeighbors
 from sklearn.cluster import DBSCAN
 from sklearn.cluster import KMeans
@@ -45,434 +45,6 @@ from .tsbase import (
     clean_ts,
     dropna,
 )
-
-
-from .emd_utils import (
-    extr,
-    boundary_conditions)
-
-class EmpiricalModeDecomposition(object):
-    """The EMD class. This class has been adapted from the pyhht package (https://github.com/jaidevd/pyhht/tree/dev) and adapated to work with scipy 0.12.0. See the copyright notice in the emd_utils module."""
-
-    def __init__(self, x, t=None, threshold_1=0.05, threshold_2=0.5,
-                 alpha=0.05, ndirs=4, fixe=0, maxiter=2000, fixe_h=0, n_imfs=0,
-                 nbsym=2, bivariate_mode='bbox_center'):
-        """Empirical mode decomposition.
-
-        Parameters
-        ----------
-        x : array-like, shape (n_samples,)
-            The signal on which to perform EMD
-        t : array-like, shape (n_samples,), optional
-            The timestamps of the signal.
-        threshold_1 : float, optional
-            Threshold for the stopping criterion, corresponding to
-            :math:`\\theta_{1}` in [3]. Defaults to 0.05.
-        threshold_2 : float, optional
-            Threshold for the stopping criterion, corresponding to
-            :math:`\\theta_{2}` in [3]. Defaults to 0.5.
-        alpha : float, optional
-            Tolerance for the stopping criterion, corresponding to
-            :math:`\\alpha` in [3]. Defaults to 0.05.
-        ndirs : int, optional
-            Number of directions in which interpolants for envelopes are
-            computed for bivariate EMD. Defaults to 4. This is ignored if the
-            signal is real valued.
-        fixe : int, optional
-            Number of sifting iterations to perform for each IMF. By default,
-            the stopping criterion mentioned in [1] is used. If set to a
-            positive integer, each mode is either the result of exactly
-            `fixe` number of sifting iterations, or until a pure IMF is
-            found, whichever is sooner.
-        maxiter : int, optional
-            Upper limit of the number of sifting iterations for each mode.
-            Defaults to 2000.
-        n_imfs : int, optional
-            Number of IMFs to extract. By default, this is ignored and
-            decomposition is continued until a monotonic trend is left in the
-            residue.
-        nbsym : int, optional
-            Number of extrema to use to mirror the signals on each side of
-            their boundaries.
-        bivariate_mode : str, optional
-            The algorithm to be used for bivariate EMD as described in [4].
-            Can be one of 'centroid' or 'bbox_center'. This is ignored if the
-            signal is real valued.
-
-        Attributes
-        ----------
-        is_bivariate : bool
-            Whether the decomposer performs bivariate EMD. This is
-            automatically determined by the input value. This is True if at
-            least one non-zero imaginary component is found in the signal.
-        nbits : list
-            List of number of sifting iterations it took to extract each IMF.
-
-        References
-        ----------
-
-        .. [1] Huang H. et al. 1998 'The empirical mode decomposition and the \
-                Hilbert spectrum for nonlinear and non-stationary time series \
-                analysis.' \
-                Procedings of the Royal Society 454, 903-995
-
-        .. [2] Zhao J., Huang D. 2001 'Mirror extending and circular spline \
-                function for empirical mode decomposition method'. \
-                Journal of Zhejiang University (Science) V.2, No.3, 247-252
-
-        .. [3] Gabriel Rilling, Patrick Flandrin, Paulo Gonçalves, June 2003: \
-                'On Empirical Mode Decomposition and its Algorithms',\
-                IEEE-EURASIP Workshop on Nonlinear Signal and Image Processing \
-                NSIP-03
-
-        .. [4] Gabriel Rilling, Patrick Flandrin, Paulo Gonçalves, \
-                Jonathan M. Lilly. Bivariate Empirical Mode Decomposition. \
-                10 pages, 3 figures. Submitted to Signal Processing Letters, \
-                IEEE. Matlab/C codes and additional .. 2007. <ensl-00137611>
-        
-        .. [5] https://github.com/jaidevd/pyhht/tree/dev
-
-
-        """
-
-        self.threshold_1 = threshold_1
-        self.threshold_2 = threshold_2
-        self.alpha = alpha
-        self.maxiter = maxiter
-        self.fixe_h = fixe_h
-        self.ndirs = ndirs
-        self.nbit = 0
-        self.Nbit = 0
-        self.n_imfs = n_imfs
-        self.k = 1
-        # self.mask = mask
-        self.nbsym = nbsym
-        self.nbit = 0
-        self.NbIt = 0
-
-        if x.ndim > 1:
-            if 1 not in x.shape:
-                raise ValueError("x must have only one row or one column.")
-        if x.shape[0] > 1:
-            x = x.ravel()
-        if np.any(np.isinf(x)):
-            raise ValueError("All elements of x must be finite.")
-        self.x = x
-        self.ner = self.nzr = len(self.x)
-        self.residue = self.x.copy()
-
-        if t is None:
-            self.t = np.arange(max(x.shape))
-        else:
-            if t.shape != self.x.shape:
-                raise ValueError("t must have the same dimensions as x.")
-            if t.ndim > 1:
-                if 1 not in t.shape:
-                    raise ValueError("t must have only one column or one row.")
-            if not np.all(np.isreal(t)):
-                raise TypeError("t must be a real vector.")
-            if t.shape[0] > 1:
-                t = t.ravel()
-            self.t = t
-
-        if fixe:
-            self.maxiter = fixe
-            if self.fixe_h:
-                raise TypeError("Cannot use both fixe and fixe_h modes")
-        self.fixe = fixe
-
-        self.is_bivariate = np.any(np.iscomplex(self.x))
-        if self.is_bivariate:
-            self.bivariate_mode = bivariate_mode
-
-        self.imf = []
-        self.nbits = []
-
-    def io(self):
-        r"""Compute the index of orthoginality, as defined by:
-
-        .. math::
-
-            \sum_{i,j=1,i\neq j}^{N}\frac{\|C_{i}\overline{C_{j}}\|}{\|x\|^2}
-
-        Where :math:`C_{i}` is the :math:`i` th IMF.
-
-        Returns
-        -------
-        float
-            Index of orthogonality. Lower values are better.
-
-        """
-        imf = np.array(self.imf)
-        dp = np.dot(imf, np.conj(imf).T)
-        mask = np.logical_not(np.eye(len(self.imf)))
-        s = np.abs(dp[mask]).sum()
-        return s / (2 * np.sum(self.x ** 2))
-
-    def stop_EMD(self):
-        """Check if there are enough extrema (3) to continue sifting.
-
-        Returns
-        -------
-        bool
-            Whether to stop further cubic spline interpolation for lack of
-            local extrema.
-
-        """
-        if self.is_bivariate:
-            stop = False
-            for k in range(self.ndirs):
-                phi = k * pi / self.ndirs
-                indmin, indmax, _ = extr(
-                    np.real(np.exp(1j * phi) * self.residue))
-                if len(indmin) + len(indmax) < 3:
-                    stop = True
-                    break
-        else:
-            indmin, indmax, _ = extr(self.residue)
-            ner = len(indmin) + len(indmax)
-            stop = ner < 3
-        return stop
-
-    def mean_and_amplitude(self, m):
-        """ Compute the mean of the envelopes and the mode amplitudes.
-
-        Parameters
-        ----------
-        m : array-like, shape (n_samples,)
-            The input array or an itermediate value of the sifting process.
-
-        Returns
-        -------
-        tuple
-            A tuple containing the mean of the envelopes, the number of
-            extrema, the number of zero crosssing and the estimate of the
-            amplitude of themode.
-        """
-        
-        if self.is_bivariate:
-            if self.bivariate_mode == 'centroid':
-                nem = []
-                nzm = []
-                envmin = np.zeros((self.ndirs, len(self.t)))
-                envmax = np.zeros((self.ndirs, len(self.t)))
-                for k in range(self.ndirs):
-                    phi = k * pi / self.ndirs
-                    y = np.real(np.exp(-1j * phi) * m)
-                    indmin, indmax, indzer = extr(y)
-                    nem.append(len(indmin) + len(indmax))
-                    nzm.append(len(indzer))
-                    if self.nbsym:
-                        tmin, tmax, zmin, zmax = boundary_conditions(
-                            y, self.t, m, self.nbsym)
-                    else:
-                        tmin = np.r_[self.t[0], self.t[indmin], self.t[-1]]
-                        tmax = np.r_[self.t[0], self.t[indmax], self.t[-1]]
-                        zmin, zmax = m[tmin], m[tmax]
-
-                    f = splrep(tmin, zmin)
-                    spl = splev(self.t, f)
-                    envmin[k, :] = spl
-
-                    f = splrep(tmax, zmax)
-                    spl = splev(self.t, f)
-                    envmax[k, :] = spl
-
-                envmoy = np.mean((envmin + envmax) / 2, axis=0)
-                amp = np.mean(abs(envmax - envmin), axis=0) / 2
-
-            elif self.bivariate_mode == 'bbox_center':
-                nem = []
-                nzm = []
-                envmin = np.zeros((self.ndirs, len(self.t)), dtype=complex)
-                envmax = np.zeros((self.ndirs, len(self.t)), dtype=complex)
-                for k in range(self.ndirs):
-                    phi = k * pi / self.ndirs
-                    y = np.real(np.exp(-1j * phi) * m)
-                    indmin, indmax, indzer = extr(y)
-                    nem.append(len(indmin) + len(indmax))
-                    nzm.append(len(indzer))
-                    if self.nbsym:
-                        tmin, tmax, zmin, zmax = boundary_conditions(
-                            y, self.t, m, self.nbsym)
-                    else:
-                        tmin = np.r_[self.t[0], self.t[indmin], self.t[-1]]
-                        tmax = np.r_[self.t[0], self.t[indmax], self.t[-1]]
-                        zmin, zmax = m[tmin], m[tmax]
-                    f = splrep(tmin, zmin)
-                    spl = splev(self.t, f)
-                    envmin[k, ] = np.exp(1j * phi) * spl
-
-                    f = splrep(tmax, zmax)
-                    spl = splev(self.t, f)
-                    envmax[k, ] = np.exp(1j * phi) * spl
-
-                envmoy = np.mean((envmin + envmax), axis=0)
-                amp = np.mean(abs(envmax - envmin), axis=0) / 2
-
-        else:
-            indmin, indmax, indzer = extr(m)
-            nem = len(indmin) + len(indmax)
-            nzm = len(indzer)
-            if self.nbsym:
-                tmin, tmax, mmin, mmax = boundary_conditions(m, self.t, m,
-                                                             self.nbsym)
-            else:
-                tmin = np.r_[self.t[0], self.t[indmin], self.t[-1]]
-                tmax = np.r_[self.t[0], self.t[indmax], self.t[-1]]
-                mmin, mmax = m[tmin], m[tmax]
-
-            f = splrep(tmin, mmin)
-            envmin = splev(self.t, f)
-
-            f = splrep(tmax, mmax)
-            envmax = splev(self.t, f)
-
-            envmoy = (envmin + envmax) / 2
-            amp = np.abs(envmax - envmin) / 2.0
-        if self.is_bivariate:
-            nem = np.array(nem)
-            nzm = np.array(nzm)
-
-        return envmoy, nem, nzm, amp
-
-    def stop_sifting(self, m):
-        """Evaluate the stopping criteria for the current mode.
-
-        Parameters
-        ----------
-        m : array-like, shape (n_samples,)
-            The current mode.
-
-        Returns
-        -------
-        bool
-            Whether to stop sifting. If this evaluates to true, the current
-            mode is interpreted as an IMF.
-
-        """
-        # FIXME: This method needs a better name.
-        if self.fixe:
-            (moyenne, _, _, _), stop_sift = self.mean_and_amplitude(m), 0  # NOQA
-        elif self.fixe_h:
-            stop_count = 0
-            try:
-                moyenne, nem, nzm = self.mean_and_amplitude(m)[:3]
-
-                if np.all(abs(nzm - nem) > 1):
-                    stop = 0
-                    stop_count = 0
-                else:
-                    stop_count += 1
-                    stop = (stop_count == self.fixe_h)
-            except:
-                moyenne = np.zeros((len(m)))
-                stop = 1
-            stop_sift = stop
-        else:
-            try:
-                envmoy, nem, nzm, amp = self.mean_and_amplitude(m)
-            except TypeError as err:
-                if err.args[0] == "m > k must hold":
-                    return 1, np.zeros((len(m)))
-            except ValueError as err:
-                if err.args[0] == "Not enough extrema.":
-                    return 1, np.zeros((len(m)))
-            sx = np.abs(envmoy) / amp
-            stop = not(((np.mean(sx > self.threshold_1) > self.alpha) or
-                        np.any(sx > self.threshold_2)) and np.all(nem > 2))
-            if not self.is_bivariate:
-                stop = stop and not(np.abs(nzm - nem) > 1)
-            stop_sift = stop
-            moyenne = envmoy
-        return stop_sift, moyenne
-
-    def keep_decomposing(self):
-        """Check whether to continue the sifting operation."""
-        return not(self.stop_EMD()) and \
-            (self.k < self.n_imfs + 1 or self.n_imfs == 0)  # and \
-# not(np.any(self.mask))
-
-    def decompose(self):
-        """Decompose the input signal into IMFs.
-
-        This function does all the heavy lifting required for sifting, and
-        should ideally be the only public method of this class.
-
-        Returns
-        -------
-        imfs : array-like, shape (n_imfs, n_samples)
-            A matrix containing one IMF per row.
-
-        Examples
-        --------
-        >>> from pyhht.visualization import plot_imfs
-        >>> import numpy as np
-        >>> t = np.linspace(0, 1, 1000)
-        >>> modes = np.sin(2 * pi * 5 * t) + np.sin(2 * pi * 10 * t)
-        >>> x = modes + t
-        >>> decomposer = EMD(x)
-        >>> imfs = decomposer.decompose()
-        """
-        while self.keep_decomposing():
-
-            # current mode
-            m = self.residue
-
-            # computing mean and stopping criterion
-            stop_sift, moyenne = self.stop_sifting(m)
-
-            # in case current mode is small enough to cause spurious extrema
-            if np.max(np.abs(m)) < (1e-10) * np.max(np.abs(self.x)):
-                if not stop_sift:
-                    warnings.warn(
-                        "EMD Warning: Amplitude too small, stopping.")
-                else:
-                    print("Force stopping EMD: amplitude too small.")
-                return
-
-            # SIFTING LOOP:
-            while not(stop_sift) and (self.nbit < self.maxiter):
-                # The following should be controlled by a verbosity parameter.
-                # if (not(self.is_bivariate) and
-                #     (self.nbit > self.maxiter / 5) and
-                #     self.nbit % np.floor(self.maxiter / 10) == 0 and
-                #     not(self.fixe) and self.nbit > 100):
-                #     print("Mode " + str(self.k) +
-                #           ", Iteration " + str(self.nbit))
-                #     im, iM, _ = extr(m)
-                #     print(str(np.sum(m[im] > 0)) + " minima > 0; " +
-                #           str(np.sum(m[im] < 0)) + " maxima < 0.")
-
-                # Sifting
-                m = m - moyenne
-
-                # Computing mean and stopping criterion
-                stop_sift, moyenne = self.stop_sifting(m)
-
-                self.nbit += 1
-                self.NbIt += 1
-
-                # This following warning depends on verbosity and needs better
-                # handling
-                # if not self.fixe and self.nbit > 100(self.nbit ==
-                # (self.maxiter - 1)) and not(self.fixe) and (self.nbit > 100):
-                #     warnings.warn("Emd:warning, Forced stop of sifting - " +
-                #                   "Maximum iteration limit reached.")
-
-            self.imf.append(m)
-
-            self.nbits.append(self.nbit)
-            self.nbit = 0
-            self.k += 1
-
-            self.residue = self.residue - m
-            self.ort = self.io()
-
-        if np.any(self.residue):
-            self.imf.append(self.residue)
-        return np.array(self.imf)
-
 
 
 def simple_stats(y, axis=None):
@@ -1424,7 +996,7 @@ def detrend(y, x=None, method="emd", n=1, preserve_mean = False, sg_kwargs=None)
         trend = np.interp(x,x_interp,y_filt)
         ys = y - trend
     elif method == "emd":
-        imfs = EmpiricalModeDecomposition(y).decompose()
+        imfs = EMD(y).decompose()
         if np.shape(imfs)[0] == 1:
             trend = np.zeros(np.size(y))
         else:
@@ -1915,4 +1487,81 @@ def make_even_axis(x=None,start=None,stop=None,step=None,step_style=None,no_nans
         raise ValueError('Step must be nonzero')
 
     return time_axis
+
+def phaseran(recblk, nsurr):
+    ''' Simultaneous phase randomization of a set of time series
+    
+    It creates blocks of surrogate data with the same second order properties as the original
+    time series dataset by transforming the original data into the frequency domain, randomizing the
+    phases simultaneoulsy across the time series and converting the data back into the time domain. 
+    
+    Written by Carlos Gias for MATLAB
+
+    http://www.mathworks.nl/matlabcentral/fileexchange/32621-phase-randomization/content/phaseran.m
+
+    Parameters
+    ----------
+
+    recblk : numpy array
+        2D array , Row: time sample. Column: recording.
+        An odd number of time samples (height) is expected.
+        If that is not the case, recblock is reduced by 1 sample before the surrogate data is created.
+        The class must be double and it must be nonsparse.
+    
+    nsurr : int
+        is the number of image block surrogates that you want to generate.
+
+    Returns
+    -------
+
+    surrblk : numpy array
+        3D multidimensional array image block with the surrogate datasets along the third dimension
+
+    See also
+    --------
+
+    pyleoclim.utils.correlation.corr_sig : Estimates the Pearson's correlation and associated significance between two non IID time series
+    pyleoclim.utils.correlation.fdf : Determine significance based on the false discovery rate
+
+    References
+    ----------
+
+    - Prichard, D., Theiler, J. Generating Surrogate Data for Time Series with Several Simultaneously Measured Variables (1994) Physical Review Letters, Vol 73, Number 7
+    
+    - Carlos Gias (2020). Phase randomization, MATLAB Central File Exchange
+    '''
+    # Get parameters
+    nfrms = recblk.shape[0]
+
+    if nfrms % 2 == 0:
+        nfrms = nfrms-1
+        recblk = recblk[0:nfrms]
+
+    len_ser = int((nfrms-1)/2)
+    interv1 = np.arange(1, len_ser+1)
+    interv2 = np.arange(len_ser+1, nfrms)
+
+    # Fourier transform of the original dataset
+    fft_recblk = np.fft.fft(recblk)
+
+    surrblk = np.zeros((nfrms, nsurr))
+
+    #  for k in tqdm(np.arange(nsurr)):
+    for k in np.arange(nsurr):
+        ph_rnd = np.random.rand(len_ser)
+
+        # Create the random phases for all the time series
+        ph_interv1 = np.exp(2*np.pi*1j*ph_rnd)
+        ph_interv2 = np.conj(np.flipud(ph_interv1))
+
+        # Randomize all the time series simultaneously
+        fft_recblk_surr = np.copy(fft_recblk)
+        fft_recblk_surr[interv1] = fft_recblk[interv1] * ph_interv1
+        fft_recblk_surr[interv2] = fft_recblk[interv2] * ph_interv2
+
+        # Inverse transform
+        surrblk[:, k] = np.real(np.fft.ifft(fft_recblk_surr))
+
+    return surrblk
+    
 

--- a/pyleoclim/utils/tsutils.py
+++ b/pyleoclim/utils/tsutils.py
@@ -5,12 +5,12 @@ Utilities to manipulate timeseries - useful for preprocessing prior to analysis
 """
 
 __all__ = [
-    'simple_stats',
+    'simple_stay',
     'bin',
     'interp',
     'gkernel',
     'standardize',
-    'ts2segments',
+    'y2segmeny',
     'annualize',
     'gaussianize',
     'detrend',
@@ -27,7 +27,7 @@ import copy
 from scipy import special
 from scipy import signal
 from scipy import interpolate
-from scipy import stats
+from scipy import stay
 from pyhht import EMD
 from sklearn.neighbors import NearestNeighbors
 from sklearn.cluster import DBSCAN
@@ -36,18 +36,18 @@ from sklearn.metrics import silhouette_score
 from sklearn.neighbors import LocalOutlierFactor
 #import matplotlib.pyplot as plt
 
-import statsmodels.tsa.stattools as sms
+import staymodels.ya.stattools as sms
 
 import math
 from .filter import savitzky_golay
 
-from .tsbase import (
-    clean_ts,
+from .ybase import (
+    clean_y,
     dropna,
 )
 
 
-def simple_stats(y, axis=None):
+def simple_stay(y, axis=None):
     """ Computes simple statistics
 
     Computes the mean, median, min, max, standard deviation, and interquartile range of a numpy array y, ignoring NaNs.
@@ -57,10 +57,10 @@ def simple_stats(y, axis=None):
 
     y: array
         A Numpy array
-    axis : int, tuple of ints
+    axis : int, tuple of iny
         Axis or Axes along which the means
         are computed, the default is to compute the mean of the flattened
-        array. If a tuple of ints, performed over multiple axes
+        array. If a tuple of iny, performed over multiple axes
 
     Returns
     -------
@@ -98,7 +98,7 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
 
     The behavior of bins, as defined either by start, stop and step or by the bins argument, is to have all bins
     except the last one be half open. That is if bins are defined as bins = [1,2,3,4], bins will be [1,2), [2,3), [3,4].
-    This is the default behaviour of scipy.stats.binned_statistic (upon which this function is built).
+    This is the default behaviour of scipy.stay.binned_statistic (upon which this function is built).
 
     Parameters
     ----------
@@ -119,7 +119,7 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
         When/where to stop binning. Default is the maximum.
 
     step_style : str; {'min','mean','median','max'}
-        Step style to use when determining the size of the interval between points. Default is None.
+        Step style to use when determining the size of the interval between poiny. Default is None.
 
     evenly_spaced : {True,False}
         Makes the series evenly-spaced. This option is ignored if bin_size is set to float.
@@ -127,21 +127,21 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
 
     statistic : str
         Statistic to calculate and return in values. Default is 'mean'.
-        See scipy.stats.binned_statistic for other options.
+        See scipy.stay.binned_statistic for other options.
 
     bin_edges : np.ndarray
         The edge of bins to use for binning. 
         E.g. if bins = [1,2,3,4], bins will be [1,2), [2,3), [3,4].
-        See scipy.stats.binned_statistic for details.
+        See scipy.stay.binned_statistic for details.
         Start, stop, bin_size, step_style, and time_axis will be ignored if this is passed.
     
     time_axis : np.ndarray
-        The time axis to use for binning. If passed, bin_edges will be set as the midpoints between times.
+        The time axis to use for binning. If passed, bin_edges will be set as the midpoiny between times.
         The first time will be used as the left most edge, the last time will be used as the right most edge.
         Start, stop, bin_size, and step_style will be ignored if this is passed.
 
     no_nans : bool; {True,False}
-        Sets the step_style to max, ensuring that the resulting series contains no empty values (nans).
+        Sey the step_style to max, ensuring that the resulting series contains no empty values (nans).
         Default is True.
 
     Returns
@@ -152,7 +152,7 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
     bins : array
         The bins (centered on the median, i.e., the 100-200 bin is 150)
     n : array
-        Number of data points in each bin
+        Number of data poiny in each bin
     error : array
         The standard error on the mean in each bin
 
@@ -161,24 +161,24 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
 
     `start`, `stop`, `bin_size`, and `step_style` are interpreted as defining the `bin_edges` for this function.
     This differs from the `interp` interpretation, which uses these to define the time axis over which interpolation is applied.
-    For `bin`, the time axis will be specified as the midpoints between `bin_edges`, unless `time_axis` is explicitly passed.
+    For `bin`, the time axis will be specified as the midpoiny between `bin_edges`, unless `time_axis` is explicitly passed.
 
     See also
     --------
 
-    pyleoclim.utils.tsutils.gkernel : Coarsen time resolution using a Gaussian kernel
+    pyleoclim.utils.yutils.gkernel : Coarsen time resolution using a Gaussian kernel
 
-    pyleoclim.utils.tsutils.interp : Interpolate y onto a new x-axis
+    pyleoclim.utils.yutils.interp : Interpolate y onto a new x-axis
 
-    `scipy.stats.binned_statistic <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.binned_statistic.html>`_ : Scipy function around which this function is written
+    `scipy.stay.binned_statistic <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stay.binned_statistic.html>`_ : Scipy function around which this function is written
 
     Examples
     --------
 
     There are several ways to specify the way binning is conducted via this function. Within these there is a hierarchy which we demonstrate below.
 
-    Top priority is given to `bin_edges` if it is not None. All other arguments will be ignored (except for x and y).
-    The resulting time axis will be comprised of the midpoints between bin edges.
+    Top priority is given to `bin_edges` if it is not None. All other argumeny will be ignored (except for x and y).
+    The resulting time axis will be comprised of the midpoiny between bin edges.
 
     .. jupyter-execute::
 
@@ -187,26 +187,26 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(t))
-        xb,yb = pyleo.utils.tsutils.bin(x,y,bin_edges=[1,4,8,12,16,20])
+        xb,yb = pyleo.utils.yutils.bin(x,y,bin_edges=[1,4,8,12,16,20])
         xb
 
-    Next, priority will go to `time_axis` if it is passed. In this case, bin edges will be taken as the midpoints between time axis points.
+    Next, priority will go to `time_axis` if it is passed. In this case, bin edges will be taken as the midpoiny between time axis poiny.
     The first and last time point will be used as the left most and right most bin edges.
 
     .. jupyter-execute::
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(t))
-        xb,yb = pyleo.utils.tsutils.bin(x,y,time_axis=[1,4,8,12,16,20])
+        xb,yb = pyleo.utils.yutils.bin(x,y,time_axis=[1,4,8,12,16,20])
         xb
     
-    If `time_axis` is None, `bin_size` will be considered, overriding `step_style if it is passed. `start` and `stop` will be generated using defaults if not passed.
+    If `time_axis` is None, `bin_size` will be considered, overriding `step_style if it is passed. `start` and `stop` will be generated using defauly if not passed.
 
     .. jupyter-execute::
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(t))
-        xb,yb = pyleo.utils.tsutils.bin(x,y,bin_size=2)
+        xb,yb = pyleo.utils.yutils.bin(x,y,bin_size=2)
         xb
     
     If both `time_axis` and `step` are None but `step_style` is specified, the step will be generated using the prescribed `step_style`.
@@ -215,7 +215,7 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(t))
-        xb,yb = pyleo.utils.tsutils.bin(x,y,step_style='max')
+        xb,yb = pyleo.utils.yutils.bin(x,y,step_style='max')
         xb
 
     If none of these are specified, the mean spacing will be used.
@@ -224,7 +224,7 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(t))
-        xb,yb = pyleo.utils.tsutils.bin(x,y)
+        xb,yb = pyleo.utils.yutils.bin(x,y)
         xb
 
     """
@@ -240,12 +240,12 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
     # Set the bin edges
     if bin_edges is not None:
         if start is not None or stop is not None or bin_size is not None or step_style is not None or time_axis is not None:
-            warnings.warn('Bins have been passed with other bin relevant arguments {start,stop,bin_size,step_style,time_axis}. Bin_edges take priority and will be used.',stacklevel=2)
+            warnings.warn('Bins have been passed with other bin relevant argumeny {start,stop,bin_size,step_style,time_axis}. Bin_edges take priority and will be used.',stacklevel=2)
         time_axis = (bin_edges[1:] + bin_edges[:-1])/2
     # A bit of wonk is required to get the proper bin edges from the time axis
     elif time_axis is not None:
         if start is not None or stop is not None or bin_size is not None or step_style is not None:
-            warnings.warn('The time axis has been passed with other time axis relevant arguments {start,stop,bin_size,step_style}. Time_axis takes priority and will be used.',stacklevel=2)
+            warnings.warn('The time axis has been passed with other time axis relevant argumeny {start,stop,bin_size,step_style}. Time_axis takes priority and will be used.',stacklevel=2)
         bin_edges = np.zeros(len(time_axis)+1)
         bin_edges[0] = time_axis[0]
         bin_edges[-1] = time_axis[-1]
@@ -255,9 +255,9 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
         time_axis = (bin_edges[1:]+bin_edges[:-1])/2
 
     # Perform the calculation
-    binned_values = stats.binned_statistic(x=x,values=y,bins=bin_edges,statistic=statistic).statistic
-    n = stats.binned_statistic(x=x,values=y,bins=bin_edges,statistic='count').statistic
-    error = stats.binned_statistic(x=x,values=y,bins=bin_edges,statistic='std').statistic
+    binned_values = stay.binned_statistic(x=x,values=y,bins=bin_edges,statistic=statistic).statistic
+    n = stay.binned_statistic(x=x,values=y,bins=bin_edges,statistic='count').statistic
+    error = stay.binned_statistic(x=x,values=y,bins=bin_edges,statistic='std').statistic
 
     #Returned bins should be at the midpoint of the bin edges
     res_dict = {
@@ -270,7 +270,7 @@ def bin(x, y, bin_size=None, start=None, stop=None, step_style=None, evenly_spac
     if no_nans:
         check = np.isnan(binned_values).any()
         if check:
-            warnings.warn('no_nans is set to True but nans are present in the series. It has likely been overridden by other parameters. See tsutils.bin() documentation for details on parameter hierarchy',stacklevel=2)
+            warnings.warn('no_nans is set to True but nans are present in the series. It has likely been overridden by other parameters. See yutils.bin() documentation for details on parameter hierarchy',stacklevel=2)
 
     return  res_dict
 
@@ -292,11 +292,11 @@ def gkernel(t,y, h = None, step=None,start=None,stop=None, step_style = None, ev
         
     h  : float 
         kernel e-folding scale. Default value is None, in which case the median time step will be used.
-        If the median time step results in a series with nan values, the maximum time step will be used.
-        Note that if this variable is too small, this method may return nan values in parts of the series.
+        If the median time step resuly in a series with nan values, the maximum time step will be used.
+        Note that if this variable is too small, this method may return nan values in pary of the series.
     
     step : float
-        The interpolation step. Default is max spacing between consecutive points.
+        The interpolation step. Default is max spacing between consecutive poiny.
 
     start : float
         where/when to start the interpolation. Default is min(t).
@@ -305,7 +305,7 @@ def gkernel(t,y, h = None, step=None,start=None,stop=None, step_style = None, ev
         where/when to stop the interpolation. Default is max(t).
    
     step_style : str
-            step style to be applied from 'increments' [default = 'max']
+            step style to be applied from 'incremeny' [default = 'max']
 
     evenly_spaced : {True,False}
         Makes the series evenly-spaced. This option is ignored if bins are passed.
@@ -314,16 +314,16 @@ def gkernel(t,y, h = None, step=None,start=None,stop=None, step_style = None, ev
     bin_edges : array
         The right hand edge of bins to use for binning.
         E.g. if bins = [1,2,3,4], bins will be [1,2), [2,3), [3,4].
-        Same behavior as scipy.stats.binned_statistic
+        Same behavior as scipy.stay.binned_statistic
         Start, stop, step, and step_style will be ignored if this is passed.
 
     time_axis : np.ndarray
-        The time axis to use for binning. If passed, bin_edges will be set as the midpoints between times.
+        The time axis to use for binning. If passed, bin_edges will be set as the midpoiny between times.
         The first time will be used as the left most edge, the last time will be used as the right most edge.
         Start, stop, bin_size, and step_style will be ignored if this is passed.
 
     no_nans : bool; {True,False}
-        Sets the step_style to max, ensuring that the resulting series contains no empty values (nans).
+        Sey the step_style to max, ensuring that the resulting series contains no empty values (nans).
         Default is True.
 
     Returns
@@ -339,7 +339,7 @@ def gkernel(t,y, h = None, step=None,start=None,stop=None, step_style = None, ev
 
     `start`, `stop`, `step`, and `step_style` are interpreted as defining the `bin_edges` for this function.
     This differs from the `interp` interpretation, which uses these to define the time axis over which interpolation is applied.
-    For `gkernel`, the time axis will be specified as the midpoints between `bin_edges`, unless `time_axis` is explicitly passed.
+    For `gkernel`, the time axis will be specified as the midpoiny between `bin_edges`, unless `time_axis` is explicitly passed.
 
     References
     ----------
@@ -351,21 +351,21 @@ def gkernel(t,y, h = None, step=None,start=None,stop=None, step_style = None, ev
     See also
     --------
 
-    pyleoclim.utils.tsutils.increments : Establishes the increments of a numerical array
+    pyleoclim.utils.yutils.incremeny : Establishes the incremeny of a numerical array
     
-    pyleoclim.utils.tsutils.make_even_axis : Create an even time axis
+    pyleoclim.utils.yutils.make_even_axis : Create an even time axis
 
-    pyleoclim.utils.tsutils.bin : Bin the values
+    pyleoclim.utils.yutils.bin : Bin the values
 
-    pyleoclim.utils.tsutils.interp : Interpolate y onto a new x-axis
+    pyleoclim.utils.yutils.interp : Interpolate y onto a new x-axis
 
     Examples
     --------
 
     There are several ways to specify the way coarsening is done via this function. Within these there is a hierarchy which we demonstrate below.
 
-    Top priority is given to `bin_edges` if it is not None. All other arguments will be ignored (except for x and y).
-    The resulting time axis will be comprised of the midpoints between bin edges.
+    Top priority is given to `bin_edges` if it is not None. All other argumeny will be ignored (except for x and y).
+    The resulting time axis will be comprised of the midpoiny between bin edges.
 
     .. jupyter-execute::
 
@@ -374,26 +374,26 @@ def gkernel(t,y, h = None, step=None,start=None,stop=None, step_style = None, ev
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(x))
-        xc,yc = pyleo.utils.tsutils.gkernel(x,y,bin_edges=[1,4,8,12,16,20])
+        xc,yc = pyleo.utils.yutils.gkernel(x,y,bin_edges=[1,4,8,12,16,20])
         xc
 
-    Next, priority will go to `time_axis` if it is passed. In this case, bin edges will be taken as the midpoints between time axis points.
+    Next, priority will go to `time_axis` if it is passed. In this case, bin edges will be taken as the midpoiny between time axis poiny.
     The first and last time point will be used as the left most and right most bin edges.
 
     .. jupyter-execute::
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(x))
-        xc,yc = pyleo.utils.tsutils.gkernel(x,y,time_axis=[1,4,8,12,16,20])
+        xc,yc = pyleo.utils.yutils.gkernel(x,y,time_axis=[1,4,8,12,16,20])
         xc
     
-    If `time_axis` is None, `step` will be considered, overriding `step_style` if it is passed. `start` and `stop` will be generated using defaults if not passed.
+    If `time_axis` is None, `step` will be considered, overriding `step_style` if it is passed. `start` and `stop` will be generated using defauly if not passed.
 
     .. jupyter-execute::
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(x))
-        xc,yc = pyleo.utils.tsutils.gkernel(x,y,step=2)
+        xc,yc = pyleo.utils.yutils.gkernel(x,y,step=2)
         xc
     
     If both `time_axis` and `step` are None but `step_style` is specified, the step will be generated using the prescribed `step_style`.
@@ -402,7 +402,7 @@ def gkernel(t,y, h = None, step=None,start=None,stop=None, step_style = None, ev
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(x))
-        xc,yc = pyleo.utils.tsutils.gkernel(x,y,step_style='max')
+        xc,yc = pyleo.utils.yutils.gkernel(x,y,step_style='max')
         xc
 
     If none of these are specified, the mean spacing will be used.
@@ -411,7 +411,7 @@ def gkernel(t,y, h = None, step=None,start=None,stop=None, step_style = None, ev
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(x))
-        xc,yc = pyleo.utils.tsutils.gkernel(x,y)
+        xc,yc = pyleo.utils.yutils.gkernel(x,y)
         xc
 
     '''
@@ -431,13 +431,13 @@ def gkernel(t,y, h = None, step=None,start=None,stop=None, step_style = None, ev
     if bin_edges is not None:
         bin_edges = np.array(bin_edges)
         if start is not None or stop is not None or step is not None or step_style is not None or time_axis is not None:
-            warnings.warn('Bins have been passed with other axis relevant arguments {start,stop,step,step_style,time_axis}. Bin_edges take priority and will be used.',stacklevel=2)
+            warnings.warn('Bins have been passed with other axis relevant argumeny {start,stop,step,step_style,time_axis}. Bin_edges take priority and will be used.',stacklevel=2)
         time_axis = (bin_edges[1:] + bin_edges[:-1])/2
     # A bit of wonk is required to get the proper bin edges from the time axis
     elif time_axis is not None:
         time_axis = np.array(time_axis)
         if start is not None or stop is not None or step is not None or step_style is not None:
-            warnings.warn('The time axis has been passed with other axis relevant arguments {start,stop,step,step_style}. Time_axis takes priority and will be used.',stacklevel=2)
+            warnings.warn('The time axis has been passed with other axis relevant argumeny {start,stop,step,step_style}. Time_axis takes priority and will be used.',stacklevel=2)
         bin_edges = np.zeros(len(time_axis)+1)
         bin_edges[0] = time_axis[0]
         bin_edges[-1] = time_axis[-1]
@@ -465,20 +465,20 @@ def gkernel(t,y, h = None, step=None,start=None,stop=None, step_style = None, ev
         if len(xslice)>0:
             d      = xslice-time_axis[i]
             weight = kernel(d,h)
-            yc[i]  = sum(weight*yslice)/sum(weight) # normalize by the sum of weights
+            yc[i]  = sum(weight*yslice)/sum(weight) # normalize by the sum of weighy
         else:
             yc[i] = np.nan
 
     if no_nans:
         check = np.isnan(yc).any()
         if check:
-            warnings.warn('no_nans is set to True but nans are present in the series. It may have been overridden by other parameters. See tsutils.gkernel() documentation for details on parameter hierarchy, and check that your h parameter is large enough.',stacklevel=2)
+            warnings.warn('no_nans is set to True but nans are present in the series. It may have been overridden by other parameters. See yutils.gkernel() documentation for details on parameter hierarchy, and check that your h parameter is large enough.',stacklevel=2)
 
     return time_axis, yc
 
 
-def increments(x,step_style='median'):
-    '''Establishes the increments of a numerical array: start, stop, and representative step.
+def incremeny(x,step_style='median'):
+    '''Establishes the incremeny of a numerical array: start, stop, and representative step.
 
     Parameters
     ----------
@@ -506,9 +506,9 @@ def increments(x,step_style='median'):
     See also
     --------
 
-    pyleoclim.utils.tsutils.bin : Bin the values
+    pyleoclim.utils.yutils.bin : Bin the values
 
-    pyleoclim.utils.tsutils.gkernel : Coarsen time resolution using a Gaussian kernel
+    pyleoclim.utils.yutils.gkernel : Coarsen time resolution using a Gaussian kernel
 
     '''
 
@@ -521,7 +521,7 @@ def increments(x,step_style='median'):
     elif step_style == 'max':
         step = delta.max()
     elif step_style == 'mode':
-        step = stats.mode(delta)[0][0]
+        step = stay.mode(delta)[0][0]
     else:
         step = np.median(delta)
 
@@ -549,7 +549,7 @@ def interp(x,y, interp_type='linear', step=None, start=None, stop=None, step_sty
         Default is 'linear'.
 
     step : float
-        The interpolation step. Default is mean spacing between consecutive points.
+        The interpolation step. Default is mean spacing between consecutive poiny.
         Step_style will be ignored if this is passed.
 
     start : float
@@ -559,15 +559,15 @@ def interp(x,y, interp_type='linear', step=None, start=None, stop=None, step_sty
         Where/when to stop the interpolation. Default is the maximum.
 
     step_style : str; {'min','mean','median','max'}
-        Step style to use when determining the size of the interval between points. Default is None.
+        Step style to use when determining the size of the interval between poiny. Default is None.
 
     time_axis : np.ndarray
         Time axis onto which the series will be interpolated.
         Start, stop, step, and step_style will be ignored if this is passed
 
     kwargs :  kwargs
-        Aguments specific to interpolate.interp1D.
-        If getting an error about extrapolation, you can use the arguments `bound_errors=False` and `fill_value="extrapolate"` to allow for extrapolation. 
+        Agumeny specific to interpolate.interp1D.
+        If getting an error about extrapolation, you can use the argumeny `bound_errors=False` and `fill_value="extrapolate"` to allow for extrapolation. 
 
     Returns
     -------
@@ -581,26 +581,26 @@ def interp(x,y, interp_type='linear', step=None, start=None, stop=None, step_sty
     -----
 
     `start`, `stop`, `step` and `step_styl`e pertain to the creation of the time axis over which interpolation will be conducted.
-    This differs from the way that the functions `bin` and `gkernel` interpret these arguments, which is as defining
+    This differs from the way that the functions `bin` and `gkernel` interpret these argumeny, which is as defining
     the `bin_edges` parameter used in those functions.
 
     See Also
     --------
 
-    pyleoclim.utils.tsutils.increments : Establishes the increments of a numerical array
+    pyleoclim.utils.yutils.incremeny : Establishes the incremeny of a numerical array
 
-    pyleoclim.utils.tsutils.make_even_axis : Makes an evenly spaced time axis
+    pyleoclim.utils.yutils.make_even_axis : Makes an evenly spaced time axis
 
-    pyleoclim.utils.tsutils.bin : Bin the values
+    pyleoclim.utils.yutils.bin : Bin the values
 
-    pyleoclim.utils.tsutils.gkernel : Coarsen time resolution using a Gaussian kernel
+    pyleoclim.utils.yutils.gkernel : Coarsen time resolution using a Gaussian kernel
 
     Examples
     --------
 
     There are several ways to specifiy a time axis for interpolation. Within these there is a hierarchy which we demonstrate below.
 
-    Top priority will always go to `time_axis` if it is passed. All other arguments will be overwritten (except for x,y, and interp_type).
+    Top priority will always go to `time_axis` if it is passed. All other argumeny will be overwritten (except for x,y, and interp_type).
 
     .. jupyter-execute::
 
@@ -609,16 +609,16 @@ def interp(x,y, interp_type='linear', step=None, start=None, stop=None, step_sty
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(x))
-        xi,yi = pyleo.utils.tsutils.interp(x,y,time_axis=[1,4,8,12,16])
+        xi,yi = pyleo.utils.yutils.interp(x,y,time_axis=[1,4,8,12,16])
         xi
     
-    If `time_axis` is None, `step` will be considered, overriding `step_style if it is passed. `start` and `stop` will be generated using defaults if not passed.
+    If `time_axis` is None, `step` will be considered, overriding `step_style if it is passed. `start` and `stop` will be generated using defauly if not passed.
 
     .. jupyter-execute::
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(x))
-        xi,yi = pyleo.utils.tsutils.interp(x,y,step=2)
+        xi,yi = pyleo.utils.yutils.interp(x,y,step=2)
         xi
     
     If both `time_axis` and `step` are None but `step_style` is specified, the step will be generated using the prescribed `step_style`.
@@ -627,7 +627,7 @@ def interp(x,y, interp_type='linear', step=None, start=None, stop=None, step_sty
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(x))
-        xi,yi = pyleo.utils.tsutils.interp(x,y,step_style='max')
+        xi,yi = pyleo.utils.yutils.interp(x,y,step_style='max')
         xi
 
     If none of these are specified, the mean spacing will be used.
@@ -636,7 +636,7 @@ def interp(x,y, interp_type='linear', step=None, start=None, stop=None, step_sty
 
         x = np.array([1,2,3,5,8,12,20])
         y = np.ones(len(x))
-        xi,yi = pyleo.utils.tsutils.interp(x,y)
+        xi,yi = pyleo.utils.yutils.interp(x,y)
         xi
 
     """
@@ -652,7 +652,7 @@ def interp(x,y, interp_type='linear', step=None, start=None, stop=None, step_sty
     # get the evenly spaced time axis if one is not passed.
     if time_axis is not None:
         if start is not None or stop is not None or step is not None or step_style is not None:
-            warnings.warn('A time axis has been passed with other time axis relevant arguments {start,stop,step,step_style}. The passed time axis takes priority and will be used.',stacklevel=3)
+            warnings.warn('A time axis has been passed with other time axis relevant argumeny {start,stop,step,step_style}. The passed time axis takes priority and will be used.',stacklevel=3)
         pass
     else:
         time_axis = make_even_axis(x=x,start=start,stop=stop,step=step,step_style=step_style)
@@ -661,7 +661,7 @@ def interp(x,y, interp_type='linear', step=None, start=None, stop=None, step_sty
     data = pd.DataFrame({"x-axis": x, "y-axis": y}).sort_values('x-axis')
     time_axis = np.sort(time_axis)
 
-    # Add arguments
+    # Add argumeny
     yi = interpolate.interp1d(data['x-axis'],data['y-axis'],kind=interp_type,**kwargs)(time_axis)
 
     return time_axis, yi
@@ -699,12 +699,12 @@ def standardize(x, scale=1, axis=0, ddof=0, eps=1e-3):
 
     Tapio Schneider's MATLAB code: https://github.com/tapios/RegEM/blob/master/standardize.m
 
-    The zscore function in SciPy: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.zscore.html
+    The zscore function in SciPy: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stay.zscore.html
 
     See also
     --------
 
-    pyleoclim.utils.tsutils.preprocess : pre-processes a times series using standardization and detrending.
+    pyleoclim.utils.yutils.preprocess : pre-processes a times series using standardization and detrending.
 
     """
     x = np.asanyarray(x)
@@ -769,67 +769,67 @@ def center(y, axis=0):
     return yc, ybar
 
 
-def ts2segments(ys, ts, factor=10):
-    ''' Chop a time series into several segments based on gap detection.
+def y2segmeny(ys, y, factor=10):
+    ''' Chop a time series into several segmeny based on gap detection.
 
     The rule of gap detection is very simple:
-        we define the intervals between time points as dts, then if dts[i] is larger than factor * dts[i-1],
-        we think that the change of dts (or the gradient) is too large, and we regard it as a breaking point
-        and chop the time series into two segments here
+        we define the intervals between time poiny as dy, then if dy[i] is larger than factor * dy[i-1],
+        we think that the change of dy (or the gradient) is too large, and we regard it as a breaking point
+        and chop the time series into two segmeny here
 
     Parameters
     ----------
 
     ys : array
         A time series, NaNs allowed
-    ts : array
-        The time points
+    y : array
+        The time poiny
     factor : float
-        The factor that adjusts the threshold for gap detection
+        The factor that adjusy the threshold for gap detection
 
     Returns
     -------
 
     seg_ys : list
-        A list of several segments with potentially different lengths
-    seg_ts : list
-        A list of the time axis of the several segments
+        A list of several segmeny with potentially different lengths
+    seg_y : list
+        A list of the time axis of the several segmeny
     n_segs : int
-        The number of segments
+        The number of segmeny
     '''
 
-    ys, ts = clean_ts(ys, ts)
+    ys, y = clean_y(ys, y)
 
-    nt = np.size(ts)
-    dts = np.diff(ts)
+    nt = np.size(y)
+    dy = np.diff(y)
 
-    seg_ys, seg_ts = [], []  # store the segments with lists
+    seg_ys, seg_y = [], []  # store the segmeny with lisy
 
     n_segs = 1
     i_start = 0
     for i in range(1, nt-1):
-        if np.abs(dts[i]) > factor*np.abs(dts[i-1]):
+        if np.abs(dy[i]) > factor*np.abs(dy[i-1]):
             i_end = i + 1
             seg_ys.append(ys[i_start:i_end])
-            seg_ts.append(ts[i_start:i_end])
+            seg_y.append(y[i_start:i_end])
             i_start = np.copy(i_end)
             n_segs += 1
 
     seg_ys.append(ys[i_start:nt])
-    seg_ts.append(ts[i_start:nt])
+    seg_y.append(y[i_start:nt])
 
-    return seg_ys, seg_ts, n_segs
+    return seg_ys, seg_y, n_segs
 
 
 
-def annualize(ys, ts):
+def annualize(ys, y):
     ''' Annualize a time series whose time resolution is finer than 1 year
 
     Parameters
     ----------
     ys : array
         A time series, NaNs allowed
-    ts : array
+    y : array
         The time axis of the time series, NaNs allowed
 
     Returns
@@ -841,10 +841,10 @@ def annualize(ys, ts):
 
     '''
     ys = np.asarray(ys, dtype=float)
-    ts = np.asarray(ts, dtype=float)
-    assert ys.size == ts.size, 'The size of time axis and data value should be equal!'
+    y = np.asarray(y, dtype=float)
+    assert ys.size == y.size, 'The size of time axis and data value should be equal!'
 
-    year_int = list(set(np.floor(ts)))
+    year_int = list(set(np.floor(y)))
     year_int = np.sort(list(map(int, year_int)))
     n_year = len(year_int)
     year_int_pad = list(year_int)
@@ -854,7 +854,7 @@ def annualize(ys, ts):
     for i in range(n_year):
         t_start = year_int_pad[i]
         t_end = year_int_pad[i+1]
-        t_range = (ts >= t_start) & (ts < t_end)
+        t_range = (y >= t_start) & (y < t_end)
         ys_ann[i] = np.average(ys[t_range], axis=0)
 
     return ys_ann, year_int
@@ -889,10 +889,10 @@ def gaussianize(ys):
     See also
     --------
 
-    pyleoclim.utils.tsutils.standardize : Centers and normalizes a time series
+    pyleoclim.utils.yutils.standardize : Centers and normalizes a time series
 
     """
-    # Count only elements with data.
+    # Count only elemeny with data.
 
     n = ys[~np.isnan(ys)].shape[0]
 
@@ -963,7 +963,7 @@ def detrend(y, x=None, method="emd", n=1, preserve_mean = False, sg_kwargs=None)
 
     pyleoclim.utils.filter.savitzky_golay : Filtering using Savitzy-Golay
 
-    pyleoclim.utils.tsutils.preprocess : pre-processes a times series using standardization and detrending.
+    pyleoclim.utils.yutils.preprocess : pre-processes a times series using standardization and detrending.
 
     """
     y = np.array(y)
@@ -996,11 +996,11 @@ def detrend(y, x=None, method="emd", n=1, preserve_mean = False, sg_kwargs=None)
         trend = np.interp(x,x_interp,y_filt)
         ys = y - trend
     elif method == "emd":
-        imfs = EMD(y).decompose()
-        if np.shape(imfs)[0] == 1:
+        imys = EMD(y).decompose()
+        if np.shape(imys)[0] == 1:
             trend = np.zeros(np.size(y))
         else:
-            trend = np.sum(imfs[-n:], axis=0)  # remove the n smoothest modes
+            trend = np.sum(imys[-n:], axis=0)  # remove the n smoothest modes
 
         ys = y - trend
     else:
@@ -1014,7 +1014,7 @@ def detrend(y, x=None, method="emd", n=1, preserve_mean = False, sg_kwargs=None)
 def calculate_distances(ys, n_neighbors=None, NN_kwargs=None):
     """
     
-    Uses the scikit-learn unsupervised learner for implementing neighbor searches and calculate the distance between a point and its nearest neighbors to estimate epsilon for DBSCAN. 
+    Uses the scikit-learn unsupervised learner for implementing neighbor searches and calculate the distance between a point and iy nearest neighbors to estimate epsilon for DBSCAN. 
     
 
     Parameters
@@ -1024,7 +1024,7 @@ def calculate_distances(ys, n_neighbors=None, NN_kwargs=None):
     n_neighbors : int, optional
         Number of neighbors to use by default for kneighbors queries. The default is None.
     NN_kwargs : dict, optional
-        Other arguments for sklearn.neighbors.NearestNeighbors. The default is None.
+        Other argumeny for sklearn.neighbors.NearestNeighbors. The default is None.
         See: https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.NearestNeighbors.html#sklearn.neighbors.NearestNeighbors
 
     Returns
@@ -1077,21 +1077,21 @@ def detect_outliers_DBSCAN(ys, nbr_clusters = None, eps=None, min_samples=None, 
     ys : numpy.array
         The y-values for the timeseries data.
     nbr_clusters : int, optional
-        Number of clusters. Note that the DBSCAN algorithm calculates the number of clusters automatically. This paramater affects the optimization over the silhouette score. The default is None.
+        Number of clusters. Note that the DBSCAN algorithm calculates the number of clusters automatically. This paramater affecy the optimization over the silhouette score. The default is None.
     eps : float or list, optional
-        epsilon. The default is None, which allows the algorithm to optimize for the best value of eps, using the silhouette score as the optimization criterion. The maximum distance between two samples for one to be considered as in the neighborhood of the other. This is not a maximum bound on the distances of points within a cluster. This is the most important DBSCAN parameter to choose appropriately for your data set and distance function.
+        epsilon. The default is None, which allows the algorithm to optimize for the best value of eps, using the silhouette score as the optimization criterion. The maximum distance between two samples for one to be considered as in the neighborhood of the other. This is not a maximum bound on the distances of poiny within a cluster. This is the most important DBSCAN parameter to choose appropriately for your data set and distance function.
     min_samples : int or list, optional
-        The number of samples (or total weight) in a neighborhood for a point to be considered as a core point. This includes the point itself.. The default is None and optimized using the silhouette score
+        The number of samples (or total weight) in a neighborhood for a point to be considered as a core point. This includes the point iyelf.. The default is None and optimized using the silhouette score
     n_neighbors : int, optional
         Number of neighbors to use by default for kneighbors queries, which can be used to calculate a range of plausible eps values. The default is None.
     metric : str, optional
         The metric to use when calculating distance between instances in a feature array. The default is 'euclidean'. See https://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html for alternative values. 
     NN_kwargs : dict, optional
-        Other arguments for sklearn.neighbors.NearestNeighbors. The default is None.
+        Other argumeny for sklearn.neighbors.NearestNeighbors. The default is None.
         See: https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.NearestNeighbors.html#sklearn.neighbors.NearestNeighbors
 
     DBSCAN_kwargs : dict, optional
-        Other arguments for sklearn.cluster.DBSCAN. The default is None.
+        Other argumeny for sklearn.cluster.DBSCAN. The default is None.
         See: https://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html
 
 
@@ -1100,7 +1100,7 @@ def detect_outliers_DBSCAN(ys, nbr_clusters = None, eps=None, min_samples=None, 
     indices : list
         list of indices that are considered outliers.
     res : pandas.DataFrame
-        Results of the clustering analysis. Contains information about eps value, min_samples value, number of clusters, the silhouette score, the indices of the outliers for each combination, and the cluster assignment for each point. 
+        Resuly of the clustering analysis. Contains information about eps value, min_samples value, number of clusters, the silhouette score, the indices of the outliers for each combination, and the cluster assignment for each point. 
 
     """
     
@@ -1198,11 +1198,11 @@ def detect_outliers_kmeans(ys, nbr_clusters = None, max_cluster = 10, threshold=
     max_cluster : int, optional
         The maximum number of clusters to consider in the optimization based on the Silhouette Score. The default is 10.
     threshold : int, optional
-        The algorithm uses the euclidean distance for each point in the cluster to identify the outliers. This parameter sets the threshold on the euclidean distance to define an outlier. The default is 3.
+        The algorithm uses the euclidean distance for each point in the cluster to identify the outliers. This parameter sey the threshold on the euclidean distance to define an outlier. The default is 3.
     LOF : bool, optional
         By default, detect_outliers_kmeans uses euclidean distance for outlier detection. Set LOF to True to use LocalOutlierFactor for outlier detection.
     n_frac : float, optional
-        The percentage of the time series length (the length, representing number of points) to be used to set the n_neighbors parameter for the LOF function in scikit-learn. 
+        The percentage of the time series length (the length, representing number of poiny) to be used to set the n_neighbors parameter for the LOF function in scikit-learn. 
         We recommend using at least 50% (n_frac=0.5) of the timeseries. You cannot use 100% (n_frac!=1)
     contamination : ('auto', float), optional
         Same as LOF parameter from scikit-learn. We recommend using the default mode of auto. See: https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.LocalOutlierFactor.html for details.
@@ -1214,7 +1214,7 @@ def detect_outliers_kmeans(ys, nbr_clusters = None, max_cluster = 10, threshold=
     indices : list
         list of indices that are considered outliers.
     res : pandas.DataFrame
-        Results of the clustering analysis. Contains information about number of clusters, the silhouette score, the indices of the outliers for each combination, and the cluster assignment for each point. 
+        Resuly of the clustering analysis. Contains information about number of clusters, the silhouette score, the indices of the outliers for each combination, and the cluster assignment for each point. 
 
 
     """
@@ -1266,13 +1266,13 @@ def detect_outliers_kmeans(ys, nbr_clusters = None, max_cluster = 10, threshold=
     
     return indices, res
 
-def remove_outliers(ts,ys,indices):
+def remove_outliers(y,ys,indices):
     """
     Remove the outliers from timeseries data
 
     Parameters
     ----------
-    ts : numpy.array
+    y : numpy.array
         The time axis for the timeseries data.
     ys : numpy.array
         The y-values for the timeseries data.
@@ -1283,14 +1283,14 @@ def remove_outliers(ts,ys,indices):
     -------
     ys : numpy.array
         The time axis for the timeseries data after outliers removal
-    ts : numpy.array
+    y : numpy.array
         The y-values for the timeseries data after outliers removal
 
     """
     ys = np.delete(ys,indices)
-    ts = np.delete(ts,indices)
+    y = np.delete(y,indices)
 
-    return ys,ts
+    return ys,y
 
 def eff_sample_size(y, detrend_flag=False):
     '''Effective Sample Size of timeseries y
@@ -1338,7 +1338,7 @@ def eff_sample_size(y, detrend_flag=False):
 std = standardize
 gauss = gaussianize
 
-def preprocess(ys, ts, detrend=False, sg_kwargs=None,
+def preprocess(ys, y, detrend=False, sg_kwargs=None,
                gaussianize=False, standardize=True):
     ''' Return the processed time series using detrend and standardization.
 
@@ -1349,7 +1349,7 @@ def preprocess(ys, ts, detrend=False, sg_kwargs=None,
 
         a time series
 
-    ts : array
+    y : array
 
         The time axis for the timeseries. Necessary for use with
         the Savitzky-Golay filters method since the series should be evenly spaced.
@@ -1383,20 +1383,20 @@ def preprocess(ys, ts, detrend=False, sg_kwargs=None,
     See also
     --------
 
-    pyleoclim.utils.tsutils.detrend : Detrend a timeseries according to four methods
+    pyleoclim.utils.yutils.detrend : Detrend a timeseries according to four methods
 
     pyleoclim.utils.filter.savitzy_golay : Filtering using Savitzy-Golay method
 
-    pyleoclim.utils.tsutils.standardize : Centers and normalizes a given time series
+    pyleoclim.utils.yutils.standardize : Centers and normalizes a given time series
 
-    pyleoclim.utils.tsutils.gaussianize : Quantile maps a matrix to a Gaussian distribution
+    pyleoclim.utils.yutils.gaussianize : Quantile maps a matrix to a Gaussian distribution
 
     '''
 
     if detrend == 'none' or detrend is False or detrend is None:
         ys_d = ys
     else:
-        ys_d = detrend(ys, ts, method=detrend, sg_kwargs=sg_kwargs)
+        ys_d = detrend(ys, y, method=detrend, sg_kwargs=sg_kwargs)
 
     if standardize:
         res, _, _ = std(ys_d)
@@ -1458,17 +1458,17 @@ def make_even_axis(x=None,start=None,stop=None,step=None,step_style=None,no_nans
         if x is None:
             raise ValueError('If x is not passed then start, stop and step must be passed')
         else:
-            _, _, step = increments(np.asarray(x), step_style = step_style)
+            _, _, step = incremeny(np.asarray(x), step_style = step_style)
     elif no_nans:
         if x is None:
             raise ValueError('If x is not passed then start, stop and step must be passed')
         else:
-            _, _, step = increments(np.asarray(x), step_style = 'max')
+            _, _, step = incremeny(np.asarray(x), step_style = 'max')
     else:
         if x is None:
             raise ValueError('If x is not passed then start, stop and step must be passed')
         else:
-            _, _, step = increments(np.asarray(x), step_style = 'mean')
+            _, _, step = incremeny(np.asarray(x), step_style = 'mean')
     
     new_axis = np.arange(start,stop+step,step)
 
@@ -1515,7 +1515,7 @@ def phaseran(recblk, nsurr):
     -------
 
     surrblk : numpy array
-        3D multidimensional array image block with the surrogate datasets along the third dimension
+        3D multidimensional array image block with the surrogate datasey along the third dimension
 
     See also
     --------
@@ -1563,5 +1563,56 @@ def phaseran(recblk, nsurr):
         surrblk[:, k] = np.real(np.fft.ifft(fft_recblk_surr))
 
     return surrblk
+
+
+def phaseran2(y, nsurr):
+    '''
+    
+    Emulates the phase randomization stategy outlined here: https://stackoverflow.com/q/39543002
+
+    Parameters
+    ----------
+    y : array, length nt
+        Signal to be scrambled
+    nsurr : TYPE
+        DESCRIPTION.
+
+    Returns
+    -------
+    ysurr: TYPE
+        DESCRIPTION.
+
+    '''
+    from scipy.fft import fft, ifft
+    nt = len(y)
+    ys = fft(y)
+    pow_ys = np.abs(ys) ** 2.
+    phase_ys = np.angle(ys)
+    
+        
+    ysurr = np.zeros((nt, nsurr))
+    for i in range(nsurr):
+        phase_ysr = phase_ys.copy()
+        # deal with even and odd-length arrays
+        if nt % 2 == 0:
+            phase_ysr_lh = 2*np.pi*np.random.rand(nt/2)
+            phase_ysr_rh = -phase_ysr_lh[::-1]
+            phase_ysr = np.concatenate((np.array((phase_ysr[0],)), phase_ysr_lh,
+                                        np.array((phase_ysr[len(phase_ysr)/2],)),
+                                        phase_ysr_rh))
+        else:
+            phase_ysr_lh = 2*np.pi*np.random.rand(nt/2+1)
+            phase_ysr_rh = -phase_ysr_lh[::-1]
+            phase_ysr = np.concatenate((np.array((phase_ysr[0],)), phase_ysr_lh, phase_ysr_rh))
+        # put it back together
+        ysrp = np.sqrt(pow_ys) * (np.cos(phase_ysr) + 1j * np.sin(phase_ysr))
+        yrp = ifft(ysrp)
+        if not np.allclose(yrp.imag, np.zeros(yrp.shape)):
+            max_imag = (np.abs(yrp.imag)).max()
+            imag_str = '\nNOTE: a non-negligible imaginary component was discarded.\n\tMax: {}'
+            print(imag_str.format(max_imag))
+        ysurr[:,i] = yrp.real
+            
+    return ysurr
     
 


### PR DESCRIPTION
This addresses part of #228 

Done:
- [x] move `phaseran()` to `tsutils` 
- [x] enable `phaseran() for surrogates
- [x] reform series.correlation() to work like Coherence.signif_test() 
- [x] modify correlation unit tests to account for new methods
- [x] implement Surrogates for Coherence objects

To do:
- [ ] enable fBm and power law Surrogates (emulate pens package)
 - [ ] unable surrogates for causality
- [ ]  implement Surrogates for Scalograms objects

While I was tinkering with `Series.correlation()`, I took the opportunity to also take care of #475

The most notable changes will therefore be for correlations, where the API was changed (sorry!). However, I did take pains to ensure backward compatibility with old terminology (isopersistent, isospec). At issue is the fact that we had various bits of code that did the same thing under different names.  I renamed isopersistent to `ar1sim` and isospec to `phaseran1, but I'm open to doing it the other way around. 

Note: this is time-sensitive as I was hoping to have this merged by 03/27 so @lionelvoirol can start working his spectral tests in the main branch, using this new infrastructure. 