### PR TITLE
Updates to spectral() behavior

### DIFF
--- a/pyleoclim/core/geoseries.py
+++ b/pyleoclim/core/geoseries.py
@@ -713,11 +713,11 @@ class GeoSeries(Series):
         if 'method' in spectral_kwargs.keys():
             pass
         else:
-            spectral_kwargs.update({'method': 'lomb_scargle'})
-        if 'freq_method' in spectral_kwargs.keys():
+            spectral_kwargs.update({'method': 'lomb_scargle'}) # unneeded as it is already the default 
+        if 'freq' in spectral_kwargs.keys():
             pass
         else:
-            spectral_kwargs.update({'freq_method': 'lomb_scargle'})
+            spectral_kwargs.update({'freq': 'lomb_scargle'})
 
         ax['spec'] = fig.add_subplot(gs[-1, -2:])
         spectralfig_kwargs = {} if spectralfig_kwargs is None else spectralfig_kwargs.copy()

--- a/pyleoclim/core/lipdseries.py
+++ b/pyleoclim/core/lipdseries.py
@@ -871,11 +871,11 @@ class LipdSeries(Series):
             pass
         else:
             spectral_kwargs.update({'method': 'lomb_scargle'})
-        if 'freq_method' in spectral_kwargs.keys():
+        if 'freq' in spectral_kwargs.keys():
             pass
         else:
             if ensemble == False:
-                spectral_kwargs.update({'freq_method': 'lomb_scargle'})
+                spectral_kwargs.update({'freq': 'lomb_scargle'})
             elif ensemble == True:
                 pass
 

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -1303,7 +1303,7 @@ class MultipleSeries:
             ms.series_list[idx]=s
         return ms
 
-    def spectral(self, method='lomb_scargle', settings=None, mute_pbar=False, freq_method='log', 
+    def spectral(self, method='lomb_scargle', freq=None, settings=None, mute_pbar=False, 
                 freq_kwargs=None, label=None, verbose=False, scalogram_list=None):
         ''' Perform spectral analysis on the timeseries
 
@@ -1312,7 +1312,14 @@ class MultipleSeries:
 
         method : str; {'wwz', 'mtm', 'lomb_scargle', 'welch', 'periodogram', 'cwt'}
 
-        freq_method : str; {'log','scale', 'nfft', 'lomb_scargle', 'welch'}
+        freq : str or array, optional
+           Information to produce the frequency vector. 
+           This can be 'log','scale', 'nfft', 'lomb_scargle' or 'welch' or a NumPy array.
+           If a string, will use make_freq_vector with the specified frequency-generating method.
+           If an array, this will be passed directly to the spectral method.
+           If None (default), will use 'log' for WWZ and 'lomb_scargle' for Lomb-Scargle. 
+           This parameter is highly consequential for the WWZ and Lomb-Scargle methods, 
+           but is otherwise ignored, as other spectral methods generate their frequency vector internally.
 
         freq_kwargs : dict
         
@@ -1395,20 +1402,20 @@ class MultipleSeries:
             #OR if the scalogram list is longer than the series list we use as many scalograms from the scalogram list as we need
             if scalogram_list_len >= series_len:
                 for idx, s in enumerate(tqdm(self.series_list, desc='Performing spectral analysis on individual series', position=0, leave=True, disable=mute_pbar)):
-                    psd_tmp = s.spectral(method=method, settings=settings, freq_method=freq_method, freq_kwargs=freq_kwargs, label=label, verbose=verbose,scalogram = scalogram_list.scalogram_list[idx])
+                    psd_tmp = s.spectral(method=method, settings=settings, freq=freq, freq_kwargs=freq_kwargs, label=label, verbose=verbose,scalogram = scalogram_list.scalogram_list[idx])
                     psd_list.append(psd_tmp)
             #If the scalogram list isn't as long as the series list, we re-use all the scalograms we can and then calculate the rest
             elif scalogram_list_len < series_len:
                 for idx, s in enumerate(tqdm(self.series_list, desc='Performing spectral analysis on individual series', position=0, leave=True, disable=mute_pbar)):
                     if idx < scalogram_list_len:
-                        psd_tmp = s.spectral(method=method, settings=settings, freq_method=freq_method, freq_kwargs=freq_kwargs, label=label, verbose=verbose,scalogram = scalogram_list.scalogram_list[idx])
+                        psd_tmp = s.spectral(method=method, settings=settings, freq=freq, freq_kwargs=freq_kwargs, label=label, verbose=verbose,scalogram = scalogram_list.scalogram_list[idx])
                         psd_list.append(psd_tmp)
                     else:
-                        psd_tmp = s.spectral(method=method, settings=settings, freq_method=freq_method, freq_kwargs=freq_kwargs, label=label, verbose=verbose)
+                        psd_tmp = s.spectral(method=method, settings=settings, freq=freq, freq_kwargs=freq_kwargs, label=label, verbose=verbose)
                         psd_list.append(psd_tmp)
         else:
             for s in tqdm(self.series_list, desc='Performing spectral analysis on individual series', position=0, leave=True, disable=mute_pbar):
-                psd_tmp = s.spectral(method=method, settings=settings, freq_method=freq_method, freq_kwargs=freq_kwargs, label=label, verbose=verbose)
+                psd_tmp = s.spectral(method=method, settings=settings, freq=freq, freq_kwargs=freq_kwargs, label=label, verbose=verbose)
                 psd_list.append(psd_tmp)
 
         psds = MultiplePSD(psd_list=psd_list)

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -1382,14 +1382,12 @@ class MultipleSeries:
 
         .. jupyter-execute::
 
-            import pyleoclim as pyleo
-            url = 'http://wiki.linked.earth/wiki/index.php/Special:WTLiPD?op=export&lipdid=MD982176.Stott.2004'
-            data = pyleo.Lipd(usr_path = url)
-            tslist = data.to_LipdSeriesList()
-            tslist = tslist[2:] # drop the first two series which only concerns age and depth
-            ms = pyleo.MultipleSeries(tslist)
-            ms_psd = ms.spectral()
-
+            soi = pyleo.utils.load_dataset('SOI')
+            nino = pyleo.utils.load_dataset('NINO3')
+            ms = soi & nino
+            ms_psd = ms.spectral(method='mtm')
+            ms_psd.plot()
+                    
         '''
         settings = {} if settings is None else settings.copy()
 

--- a/pyleoclim/core/psds.py
+++ b/pyleoclim/core/psds.py
@@ -249,14 +249,11 @@ class PSD:
         '''
         from ..core.surrogateseries import SurrogateSeries
 
-        if self.spec_method == 'wwz' and method == 'ar1asym':
+        if self.spec_method in ['wwz','lomb_scargle'] and method == 'ar1asym':
             raise ValueError('Asymptotic solution is not supported for the wwz method')
 
-        if self.spec_method == 'lomb_scargle' and method == 'ar1asym':
-            raise ValueError('Asymptotic solution is not supported for the Lomb-Scargle method')
-
         if method not in ['ar1sim', 'uar1','ar1asym']:
-                raise ValueError("The available methods are 'ar1sim' and 'ar1asym'")
+                raise ValueError("The available methods are 'ar1sim', 'uar1' and 'ar1asym'")
 
         if method in ['ar1sim', 'uar1']:
             signif_scals = None
@@ -283,7 +280,7 @@ class PSD:
                     method=self.spec_method, settings=self.spec_args, scalogram_list=signif_scals
                 )
             else:
-                surr_psd = surr.spectral(method=self.spec_method, freq=self.spec_args['freq'], settings=self.spec_args)
+                surr_psd = surr.spectral(method=self.spec_method, settings=self.spec_args)
             new.signif_qs = surr_psd.quantiles(qs=qs)
             new.signif_method = method
 
@@ -310,7 +307,7 @@ class PSD:
                                                        self.spec_args['param'],
                                                        qs=qs, **settings)
             else:
-                # hard code Mortlet values to obtain the spectrum
+                # hard code Morlet values to obtain the spectrum
                 param = 6
                 fourier_factor = 4 * np.pi / (param + np.sqrt(2 + param**2))
                 scale = 1/(fourier_factor*self.frequency)

--- a/pyleoclim/core/psds.py
+++ b/pyleoclim/core/psds.py
@@ -283,7 +283,7 @@ class PSD:
                     method=self.spec_method, settings=self.spec_args, scalogram_list=signif_scals
                 )
             else:
-                surr_psd = surr.spectral(method=self.spec_method, settings=self.spec_args)
+                surr_psd = surr.spectral(method=self.spec_method, freq=self.spec_args['freq'], settings=self.spec_args)
             new.signif_qs = surr_psd.quantiles(qs=qs)
             new.signif_method = method
 

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -2922,7 +2922,6 @@ class Series:
             psd_mtm2 = ts_interp.spectral(method='mtm', settings={'NW':2}, label='MTM, NW=2')
             fig, ax = psd_mtm2.plot(title='MTM with NW=2')
 
-
         - Continuous Wavelet Transform
 
         .. jupyter-execute::
@@ -2931,7 +2930,6 @@ class Series:
             psd_cwt = ts_interp.spectral(method='cwt')
             psd_cwt_signif = psd_cwt.signif_test(number=20)
             fig, ax = psd_cwt_signif.plot(title='PSD using the CWT method')
-
 
         '''
         if not verbose:
@@ -2949,25 +2947,28 @@ class Series:
         args = {}
         freq_kwargs = {} if freq_kwargs is None else freq_kwargs.copy()
         
-        if freq is None: # assign the frequency method automatically based on context
-            if method in ['wwz','cwt']:
-                freq_vec = specutils.make_freq_vector(self.time, method='log', **freq_kwargs) 
-            elif method=='lomb_scargle':
-                freq_vec = specutils.make_freq_vector(self.time, method='lomb_scargle', **freq_kwargs) 
-            else:
-                warnings.warn(f'freq argument gnored; it is determined automatically by {method}')
-        elif isinstance(freq, str):   # apply the specified method     
-            freq_vec = specutils.make_freq_vector(self.time, method=freq, **freq_kwargs) 
-        elif isinstance(freq,np.ndarray): # use the specified vector if dimensions check out
-            freq_vec = np.squeeze(freq)
-            if freq.ndim != 1:
-                raise ValueError("freq should be a 1-dimensional array")
+        if 'freq' in settings.keys():
+            freq_vec = settings['freq']
+        else:
+            if freq is None: # assign the frequency method automatically based on context
+                if method in ['wwz','cwt']:
+                    freq_vec = specutils.make_freq_vector(self.time, method='log', **freq_kwargs) 
+                elif method=='lomb_scargle':
+                    freq_vec = specutils.make_freq_vector(self.time, method='lomb_scargle', **freq_kwargs) 
+                else:
+                    warnings.warn(f'freq argument ignored; it is determined automatically by {method}')
+            elif isinstance(freq, str):   # apply the specified method     
+                freq_vec = specutils.make_freq_vector(self.time, method=freq, **freq_kwargs) 
+            elif isinstance(freq,np.ndarray): # use the specified vector if dimensions check out
+                freq_vec = np.squeeze(freq)
+                if freq.ndim != 1:
+                    raise ValueError("freq should be a 1-dimensional array")
         
         # pass frequency
         if method in ['wwz','cwt','lomb_scargle']:
             args[method] = {'freq': freq_vec}
         else:
-            args[method] = {'freq': None}
+            args[method] = {}
             
         # args['mtm'] = {'freq': freq_vec}
         # args['welch'] = {}

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -213,7 +213,7 @@ class TestUISeriesSpectral:
         beta = psd.beta_est().beta_est_res['beta']
         assert np.abs(beta-1.0) < eps
 
-    @pytest.mark.parametrize('freq_method', ['log', 'scale', 'nfft', 'lomb_scargle', 'welch'])
+    @pytest.mark.parametrize('freq', ['log', 'scale', 'nfft', 'lomb_scargle', 'welch'])
     def test_spectral_t1(self, pinkseries, freq_method, eps=0.3):
         ''' Test Series.spectral() with MTM using available `freq_method` options with other arguments being default
 
@@ -248,12 +248,12 @@ class TestUISeriesSpectral:
 
     @pytest.mark.parametrize('dt, nf, ofac, hifac', [(None, 20, 1, 1), (None, None, 2, 0.5)])
     def test_spectral_t4(self, pinkseries, dt, nf, ofac, hifac, eps=0.5):
-        ''' Test Series.spectral() with Lomb_Scargle using `freq_method=lomb_scargle` with different values for its keyword arguments
+        ''' Test Series.spectral() with Lomb_Scargle using `freq=lomb_scargle` with different values for its keyword arguments
 
         We will estimate the scaling slope of an ideal colored noise to make sure the result is reasonable.
         '''
         ts = pinkseries
-        psd = ts.spectral(method='mtm', freq_method='lomb_scargle', freq_kwargs={'dt': dt, 'nf': nf, 'ofac': ofac, 'hifac': hifac})
+        psd = ts.spectral(method='mtm', freq='lomb_scargle', freq_kwargs={'dt': dt, 'nf': nf, 'ofac': ofac, 'hifac': hifac})
         beta = psd.beta_est().beta_est_res['beta']
         assert np.abs(beta-1.0) < eps
 
@@ -266,7 +266,7 @@ class TestUISeriesSpectral:
         '''
         ts = pinkseries
         freq = np.linspace(1/500, 1/2, 100)
-        psd = ts.spectral(method='wwz', settings={'freq': freq}, label='WWZ')
+        psd = ts.spectral(method='wwz', freq=freq, label='WWZ')
         beta = psd.beta_est(fmin=1/200, fmax=1/10).beta_est_res['beta']
         assert_array_equal(psd.frequency, freq)
         assert np.abs(beta-1.0) < eps

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -214,35 +214,35 @@ class TestUISeriesSpectral:
         assert np.abs(beta-1.0) < eps
 
     @pytest.mark.parametrize('freq', ['log', 'scale', 'nfft', 'lomb_scargle', 'welch'])
-    def test_spectral_t1(self, pinkseries, freq_method, eps=0.3):
-        ''' Test Series.spectral() with MTM using available `freq_method` options with other arguments being default
+    def test_spectral_t1(self, pinkseries, freq, eps=0.3):
+        ''' Test Series.spectral() with MTM using available `freq` options with other arguments being default
 
         We will estimate the scaling slope of an ideal colored noise to make sure the result is reasonable.
         '''
         ts = pinkseries
-        psd = ts.spectral(method='mtm', freq_method=freq_method)
+        psd = ts.spectral(method='mtm', freq=freq)
         beta = psd.beta_est().beta_est_res['beta']
         assert np.abs(beta-1.0) < eps
 
     @pytest.mark.parametrize('nf', [10, 20, 30])
     def test_spectral_t2(self, pinkseries, nf, eps=0.3):
-        ''' Test Series.spectral() with MTM using `freq_method='log'` with different values for its keyword argument `nfreq`
+        ''' Test Series.spectral() with MTM using `freq='log'` with different values for its keyword argument `nfreq`
 
         We will estimate the scaling slope of an ideal colored noise to make sure the result is reasonable.
         '''
         ts = pinkseries
-        psd = ts.spectral(method='mtm', freq_method='log', freq_kwargs={'nf': nf})
+        psd = ts.spectral(method='mtm', freq='log', freq_kwargs={'nf': nf})
         beta = psd.beta_est().beta_est_res['beta']
         assert np.abs(beta-1.0) < eps
 
     @pytest.mark.parametrize('dj', [0.25, 0.5, 1])
     def test_spectral_t3(self, pinkseries, dj, eps=0.3):
-        ''' Test Series.spectral() with MTM using `freq_method='scale'` with different values for its keyword argument `nv`
+        ''' Test Series.spectral() with MTM using `freq='scale'` with different values for its keyword argument `nv`
 
         We will estimate the scaling slope of an ideal colored noise to make sure the result is reasonable.
         '''
         ts = pinkseries
-        psd = ts.spectral(method='mtm', freq_method='scale', freq_kwargs={'dj': dj})
+        psd = ts.spectral(method='mtm', freq='scale', freq_kwargs={'dj': dj})
         beta = psd.beta_est().beta_est_res['beta']
         assert np.abs(beta-1.0) < eps
 
@@ -258,7 +258,7 @@ class TestUISeriesSpectral:
         assert np.abs(beta-1.0) < eps
 
     def test_spectral_t5(self, pinkseries, eps=0.6):
-        ''' Test Series.spectral() with WWZ with specified frequency vector passed via `settings`
+        ''' Test Series.spectral() with LS with specified frequency vector passed via `settings`
 
         We will estimate the scaling slope of an ideal colored noise to make sure the result is reasonable.
         Note `asser_array_equal(psd.frequency, freq)` is used to make sure the specified frequency vector is really working.
@@ -266,7 +266,7 @@ class TestUISeriesSpectral:
         '''
         ts = pinkseries
         freq = np.linspace(1/500, 1/2, 100)
-        psd = ts.spectral(method='wwz', freq=freq, label='WWZ')
+        psd = ts.spectral(method='lomb_scargle', freq=freq)
         beta = psd.beta_est(fmin=1/200, fmax=1/10).beta_est_res['beta']
         assert_array_equal(psd.frequency, freq)
         assert np.abs(beta-1.0) < eps
@@ -284,7 +284,7 @@ class TestUISeriesSpectral:
         t_unevenly =  np.delete(ts.time, deleted_idx)
         v_unevenly =  np.delete(ts.value, deleted_idx)
 
-        ts2 = pyleo.Series(time=t_unevenly, value=v_unevenly)
+        ts2 = pyleo.Series(time=t_unevenly, value=v_unevenly,auto_time_params=True)
         psd = ts2.spectral(method=spec_method)
         beta = psd.beta_est().beta_est_res['beta']
         assert np.abs(beta-1.0) < eps

--- a/pyleoclim/utils/spectral.py
+++ b/pyleoclim/utils/spectral.py
@@ -346,10 +346,10 @@ def lomb_scargle(ys, ts, freq=None, freq_method='lomb_scargle',
                  gaussianize=False,
                  standardize=True,
                  average='mean'):
-    """ Lomb-scargle priodogram
+    """ Lomb-scargle periodogram
 
     Appropriate for unevenly-spaced arrays.
-    Uses the lomb-scargle implementation from scipy.signal: https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.lombscargle.html
+    Uses the lomb-scargle implementation: https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.lombscargle.html
 
     Parameters
     ----------
@@ -1281,6 +1281,6 @@ def psd_fBM(freq, ts, H):
 
     for k in range(nf):
         tmp = 2 * omega[k] * T
-        psd[k] = (1 - 2**(1 - 2*H)*np.sin(tmp)/tmp) / np.abs(omega[k])**(1 + 2*H)
+        psd[k] = (1 - 2**(1 - 2*H)*np.sin(tmp)/tmp) / np.abs(omega[k])**(1 + 2*H) # Eq 6 from Flandrin, 1989
 
     return psd

--- a/pyleoclim/utils/spectral.py
+++ b/pyleoclim/utils/spectral.py
@@ -472,8 +472,6 @@ def lomb_scargle(ys, ts, freq=None, freq_method='lomb_scargle',
 
     Scargle, J. D. (1982). Studies in astronomical time series analysis. II. Statistical aspects of spectral analyis of unvenly spaced data. The Astrophysical Journal, 263(2), 835-853.
 
-    Scargle, J. D. (1982). Studies in astronomical time series analysis. II. Statistical aspects of spectral analyis of unvenly spaced data. The Astrophysical Journal, 263(2), 835-853.
-
     """
     
     if standardize == True:


### PR DESCRIPTION
Addresses #536 
Summary of changes:

- the `freq_method` kwarg has been replaced by `freq`, which can be str or array. If a string, will use make_freq_vector with the specified frequency-generating method. If an array, this will be passed directly to the spectral method.
- the default frequency method for `Series.spectral()` is no longer 'log' ; it is now `None`, and the code assigns `freq` depending on method. (e.g. `method=wwz` triggers `freq=log`, but `method = lomb_scargle`  triggers `freq = lomb_scargle` ). Of course, that can be overridden easily, and users can still force `freq = log` with any method if they so choose. Evenly-spaced methods (e.g. MTM) are not affected. 

- `make_freq_vector()` now has a new argument, `rayleigh_bound`, which forces the lowest frequency to be the Rayleigh frequency (f_R) if set to True, which is the default. I am not passing this at the API level, because in my mind, if people are going to screw around with a custom frequency vector, they can generate it themselves (using make_freq_vector for instance) and pass it to the method as `freq`. We’ve historically done this through settings. I don’t mind making this an extra argument but I don’t really see the point.

- freq_vector_lomb_scargle()used to have default ofac=4, hifac=1.0. I’ve now reduced the default hifac to 0.95 to avoid the weirdness at the Nyquist frequency. Open to other suggestions.

- freq_vector_log used to assign a default fmin that was 2*f_R. I’m not sure where that came from (naturally it was not explained anywhere), and it created discrepancies with the other methods. I’ve now aligned that so fmin = f_R if None is provided to the method.

- docstrings have been updated, but I have not rebuilt the docs, so I expect some minor bugs. Similarly, the spectral PyleoTutorial will need a major overhaul, which I'm happy to do once this is approved. 
