### PR TITLE
include np.squeeze in series init

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -153,6 +153,12 @@ class Series:
         time = np.array(time)
         value = np.array(value)
 
+        # ensure 1D arrays
+        if len(time) > 1:
+            time = np.squeeze(time)
+        if len(value) > 1:
+            value = np.squeeze(value)
+
         if auto_time_params is None:
             auto_time_params = True
             if verbose:


### PR DESCRIPTION
Squeeze out additional dimensions from `time` and `value` in `pyleo.Series` init call. This is only done when the `time` and `value` have more than one value, as otherwise the time/value itself gets squeezed out.

Addresses #547 