### PR TITLE
EnsembleSeries display

### DIFF
--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -40,7 +40,6 @@ class EnsembleSeries(MultipleSeries):
     def __init__(self, series_list, label=None):
         for i, ts in enumerate(series_list):
             if ts.label is None:
-                print("assign labels if missing")
                 series_list[i].label = f"#{i}"  # assign labels if missing
         self.series_list = series_list
         self.label = label
@@ -1381,7 +1380,7 @@ class EnsembleSeries(MultipleSeries):
         
         if axis == 'value':
             for ts in self.series_list:
-                if ts.label is None:
+                if ts.label is None: # should no longer be necessary now that it's done in __init__
                     df_dict[idx]=ts.value
                 else:
                     df_dict[ts.label]=ts.value
@@ -1389,7 +1388,7 @@ class EnsembleSeries(MultipleSeries):
         
         elif axis == 'time':
             for ts in self.series_list:
-                if ts.label is None:
+                if ts.label is None: # should no longer be necessary now that it's done in __init__
                     df_dict[idx]=ts.time
                 else:
                     df_dict[ts.label]=ts.time

--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -36,7 +36,12 @@ class EnsembleSeries(MultipleSeries):
     and visualization (e.g., envelope plot) that are unavailable to other classes.
 
     '''
+    
     def __init__(self, series_list, label=None):
+        for i, ts in enumerate(series_list):
+            if ts.label is None:
+                print("assign labels if missing")
+                series_list[i].label = f"#{i}"  # assign labels if missing
         self.series_list = series_list
         self.label = label
 


### PR DESCRIPTION

addresses #574

Instead of creating a custom` __repr__` function, I simply made sure that all ensemble members have a label upon init, and the pandas ` __repr__` function did the rest. Some clauses in `EnsembleSeries.to_dataframe()` may no longer be necessary. Incidentally, it would be more consistent to call that function `to_pandas()`, to align with `Series` or `MultipleSeries`