### PR TITLE
fix typo in if statement in coherence.plot

### DIFF
--- a/pyleoclim/core/coherences.py
+++ b/pyleoclim/core/coherences.py
@@ -410,7 +410,7 @@ class Coherence:
                 plotting.savefig(fig, settings=savefig_settings)
             if title is not None and  title != 'auto':
                 fig.suptitle(title)
-            elif title == 'auto' and lbl1 is not None and lbl1 is not None:
+            elif title == 'auto' and lbl1 is not None and lbl2 is not None:
                 title = 'Wavelet coherency ('+self.wave_method.upper() +') between '+ lbl1 + ' and ' + lbl2
                 fig.suptitle(title)
             return fig, ax


### PR DESCRIPTION
typo in if statement lead to coherence.plot throwing and error when series were not both labelled