### PR TITLE
Fix problems with graphics

### DIFF
--- a/pyleoclim/core/ensemblegeoseries.py
+++ b/pyleoclim/core/ensemblegeoseries.py
@@ -632,7 +632,6 @@ class EnsembleGeoSeries(EnsembleSeries):
         if self.archiveType is not None:
             archiveType = lipdutils.LipdToOntology(self.archiveType)
             if archiveType not in lipdutils.PLOT_DEFAULT.keys():
-                print(archiveType)
                 archiveType = 'Other'                
         else: 
             archiveType = 'Other'

--- a/pyleoclim/core/ensemblegeoseries.py
+++ b/pyleoclim/core/ensemblegeoseries.py
@@ -614,8 +614,8 @@ class EnsembleGeoSeries(EnsembleSeries):
         plt_kwargs.update({'ax': ax['ts']})
         # use the defaults if color/markers not specified
         
-        if self.archiveType is not None:
-            archiveType = lipdutils.LipdToOntology(self.archiveType)
+        if self.series_list[0].archiveType is not None:
+            archiveType = lipdutils.LipdToOntology(self.series_list[0].archiveType)
             if archiveType not in lipdutils.PLOT_DEFAULT.keys():
                 archiveType = 'Other'                
         else: 

--- a/pyleoclim/core/ensemblegeoseries.py
+++ b/pyleoclim/core/ensemblegeoseries.py
@@ -634,7 +634,16 @@ class EnsembleGeoSeries(EnsembleSeries):
             if archiveType not in lipdutils.PLOT_DEFAULT.keys():
                 archiveType = 'Other'                
         else: 
-            archiveType = 'Other'
+            if not all([isinstance(ts, GeoSeries) for ts in self.series_list]):
+                archiveType = 'Other'
+            else:
+                archiveList = [str(ts.archiveType) for ts in self.series_list]
+                #Check that they're all the same
+                if all([a == archiveList[0] for a in archiveList]):
+                    archiveType = archiveList[0]
+                #If they aren't, pick the most common one
+                else:
+                    archiveType = Counter(archiveList).most_common(1)[0][0]
         # if 'marker' not in plt_kwargs.keys():
         #     plt_kwargs.update({'marker': lipdutils.PLOT_DEFAULT[archiveType][1]})
         if 'curve_clr' not in plt_kwargs.keys():

--- a/pyleoclim/core/ensemblegeoseries.py
+++ b/pyleoclim/core/ensemblegeoseries.py
@@ -13,6 +13,8 @@ from ..utils import mapping, lipdutils, plotting
 
 import warnings
 
+from collections import Counter
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
@@ -85,6 +87,19 @@ class EnsembleGeoSeries(EnsembleSeries):
                  sensorType = None, observationType = None, depth = None, depth_name = None, depth_unit= None):
 
         super().__init__(series_list,label)
+
+        # Assign archiveType if it isn't passed and it is present in all series in series_list
+        if archiveType is None:
+            if not all([isinstance(ts, GeoSeries) for ts in series_list]):
+                pass
+            else:
+                archiveList = [str(ts.archiveType) for ts in series_list]
+                #Check that they're all the same
+                if all([a == archiveList[0] for a in archiveList]):
+                    archiveType = archiveList[0]
+                #If they aren't, pick the most common one
+                else:
+                    archiveType = Counter(archiveList).most_common(1)[0][0]
 
         if lat is None:
             # check that all components are GeoSeries
@@ -614,13 +629,13 @@ class EnsembleGeoSeries(EnsembleSeries):
         plt_kwargs.update({'ax': ax['ts']})
         # use the defaults if color/markers not specified
         
-        if self.series_list[0].archiveType is not None:
-            archiveType = lipdutils.LipdToOntology(self.series_list[0].archiveType)
+        if self.archiveType is not None:
+            archiveType = lipdutils.LipdToOntology(self.archiveType)
             if archiveType not in lipdutils.PLOT_DEFAULT.keys():
+                print(archiveType)
                 archiveType = 'Other'                
         else: 
             archiveType = 'Other'
-        
         # if 'marker' not in plt_kwargs.keys():
         #     plt_kwargs.update({'marker': lipdutils.PLOT_DEFAULT[archiveType][1]})
         if 'curve_clr' not in plt_kwargs.keys():

--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -13,6 +13,7 @@ from ..core.correns import CorrEns
 from ..core.multipleseries import MultipleSeries
 
 import warnings
+warnings.filterwarnings("ignore")
 
 import seaborn as sns
 import matplotlib.pyplot as plt
@@ -666,7 +667,7 @@ class EnsembleSeries(MultipleSeries):
         return corr_ens
 
     def plot_traces(self, figsize=[10, 4], xlabel=None, ylabel=None, title=None, num_traces=10, seed=None,
-             xlim=None, ylim=None, linestyle='-', savefig_settings=None, ax=None, plot_legend=True,
+             xlim=None, ylim=None, linestyle='-', savefig_settings=None, ax=None, legend=True,
              color=sns.xkcd_rgb['pale red'], lw=0.5, alpha=0.3, lgd_kwargs=None):
         '''Plot EnsembleSeries as a subset of traces.
 
@@ -804,8 +805,8 @@ class EnsembleSeries(MultipleSeries):
 
             for idx in random_draw_idx:
                 self.series_list[idx].plot(xlabel=xlabel, ylabel=ylabel, zorder=99, linewidth=lw,
-                    xlim=xlim, ylim=ylim, ax=ax, color=color, alpha=alpha,linestyle='-')
-            ax.plot(np.nan, np.nan, color=color, label=f'example members (n={num_traces})',linestyle='-')
+                    xlim=xlim, ylim=ylim, ax=ax, color=color, alpha=alpha,linestyle='-', label='_ignore')
+            l1, = ax.plot(np.nan, np.nan, color=color, label=f'example members (n={num_traces})',linestyle='-')
 
         if title is not None:
             ax.set_title(title)
@@ -813,10 +814,14 @@ class EnsembleSeries(MultipleSeries):
             if self.label is not None:
                 ax.set_title(self.label)
             
-        if plot_legend:
+        if legend==True:
             lgd_args = {'frameon': False}
             lgd_args.update(lgd_kwargs)
             ax.legend(**lgd_args)
+        elif legend==False:
+            ax.legend().remove()
+        else:
+            raise ValueError('legend should be set to either True or False')
 
         if 'fig' in locals():
             if 'path' in savefig_settings:


### PR DESCRIPTION
This fixes two issues encountered with `EnsembleSeries` and `EnsembleGeoSeries` graphics:

1. Issue #602  Changes to the Matplotlib API required to put a label with an underscore on the traces to avoid having a legend entry for everything since these are ignored. Another solution was found: passing the handles directly to legend; however this would result in the traces showing up again is another line was added to the plot. 
2. Issue #598 The code was lifted directly from the `GeoSeries.dashboard` resulting in `self.archiveType` being always `None`. Needed to set it to the `archiveType` in the first entry in the `series_list`. 