### PR TITLE
Fix a bug in series.py that was preventing values to be assigned correctly when changing the time axis

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -767,7 +767,7 @@ class Series:
             new_value = self.copy().value
 
         new_ts.time = new_time
-        new_ts.new_value = new_value
+        new_ts.value = new_value
         new_ts.time_unit = time_unit
         new_ts.time_name = time_name
 


### PR DESCRIPTION
Small mistake in series.py:

changed line 770 from `new_ts.new_value = new_value` to `new_ts.value = new_value` to properly assign the parameters of the time series, 