### PR TITLE
ignorable labels in MultiplePSD.plot_envelope() + update version

### DIFF
--- a/pyleoclim/core/psds.py
+++ b/pyleoclim/core/psds.py
@@ -1365,7 +1365,7 @@ class MultiplePSD:
                 self.psd_list[idx].plot(
                     in_loglog=in_loglog, in_period=in_period, xlabel=xlabel, ylabel=ylabel,
                     xlim=xlim, ylim=ylim, xticks=xticks, yticks=yticks, ax=ax, color='gray', alpha=members_alpha,
-                    zorder=99, linewidth=members_lw,
+                    zorder=99, linewidth=members_lw, label='_ignore'
                 )
             ax.plot(np.nan, np.nan, color='gray', label=f'example members (n={members_plot_num})')
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-version = '1.0.1b0'
+version = '1.1.0b0'
 
 # Read the readme file contents into variable
 def read(fname):


### PR DESCRIPTION
applied @khider 's trick from `EnsembleSeries.plot_traces()` to `MultiplePSD.plot_envelope()` to avoid being swamped by labels, and updated the package version, which had not been properly ticked on the last update 