### PR TITLE
Doc fixes

### DIFF
--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -728,7 +728,7 @@ class EnsembleSeries(MultipleSeries):
 
             Matplotlib axis on which to return the plot. The default is None.
 
-        plot_legend : bool; {True,False}, optional
+        legend : bool; {True,False}, optional
 
             Whether to plot the legend. The default is True.
 

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3534,11 +3534,11 @@ class Series:
 
         The significance of the correlation is assessed using one of the following methods:
 
-        1) 'ttest': T-test adjusted for effective sample size, see [1]
-        2) 'ar1sim': AR(1) modeling of x and y (Monte Carlo method)
-        3) 'CN': colored noise (power-law spectrum) modeling of x and y (Monte Carlo method)
-        3) 'phaseran': phase randomization of original inputs. (Monte Carlo method, default), see [2]
-        4) 'built-in': uses built-in method
+        1. 'ttest': T-test adjusted for effective sample size, see [1]
+        2. 'ar1sim': AR(1) modeling of x and y (Monte Carlo method)
+        3. 'CN': colored noise (power-law spectrum) modeling of x and y (Monte Carlo method)
+        4. 'phaseran': phase randomization of original inputs. (Monte Carlo method, default), see [2]
+        5. 'built-in': uses built-in method from scipy (function of the statistic used)
 
         Note: Up to version v0.14.0. ar1sim was called "isopersistent",  phaseran was called "isospectral"
 
@@ -3561,12 +3561,13 @@ class Series:
                 Currently supported: ['pearsonr','spearmanr','pointbiserialr','kendalltau','weightedtau']
             Default: 'pearsonr'.
 
-        method : str, {'ttest','built-in','ar1sim','phaseran'}
+        method : str, {'ttest','built-in','ar1sim','phaseran','CN'}
             method for significance testing. Default is 'phaseran'
-            * 'ttest' implements the T-test with degrees of freedom adjusted for autocorrelation, as done in [1]
-            * 'built-in' uses the p-value that ships with the SciPy function.
-            * 'ar1sim' (formerly 'isopersistent') tests against an ensemble of AR(1) seires fitted to the originals  
-            * 'phaseran' (formerly 'isospectral') tests against phase-randomized surrogates (aka the method of Ebisuzaki [2])
+            - 'ttest' implements the T-test with degrees of freedom adjusted for autocorrelation, as done in [1]
+            - 'built-in' uses the p-value that ships with the SciPy function.
+            - 'ar1sim' (formerly 'isopersistent') tests against an ensemble of AR(1) series fitted to the originals  
+            - 'CN' tests against an ensemble of colored noise series (power-law spectra) fitted to the originals
+            - 'phaseran' (formerly 'isospectral') tests against phase-randomized surrogates (aka the method of Ebisuzaki [2])
             The old options 'isopersistent' and 'isospectral' still work, but trigger a deprecation warning.
             Note that 'weightedtau' does not have a known distribution, so the 'built-in' method returns an error in that case.
 

--- a/pyleoclim/tests/test_core_MultipleSeries.py
+++ b/pyleoclim/tests/test_core_MultipleSeries.py
@@ -45,7 +45,7 @@ def gen_colored_noise(alpha=1, nt=100, std=1.0, f0=None, m=None, seed=None):
     v = colored_noise(alpha=alpha, t=t, std=std, f0=f0, m=m, seed=seed)
     return t, v
     
-def load_data():
+def load_ms():
     soi = pyleo.utils.load_dataset('SOI')
     nino = pyleo.utils.load_dataset('NINO3')
     ms = soi & nino
@@ -450,33 +450,55 @@ class TestMultipleSeriesStackPlot():
     @pytest.mark.parametrize('labels', [None, 'auto', ['soi','nino']])
     def test_StackPlot_t0(self, labels):
     
-        ms = load_data()
+        ms = load_ms()
         fig, ax = ms.stackplot(labels=labels)
         pyleo.closefig(fig)
     
     @pytest.mark.parametrize('plot_kwargs', [{'marker':'o'},[{'marker':'o'},{'marker':'^'}]])
     def test_StackPlot_t1(self, plot_kwargs):
-        ms = load_data()
+        ms = load_ms()
         fig, ax = ms.stackplot(plot_kwargs=plot_kwargs)
         pyleo.closefig(fig)
         
     @pytest.mark.parametrize('ylims', ['spacious', 'auto'])
     def test_StackPlot_t2(self, ylims):
-        ms = load_data()
+        ms = load_ms()
         fig, ax = ms.stackplot(ylims=ylims)
         pyleo.closefig(fig)
         
     @pytest.mark.parametrize('yticks_minor', [True, False])
     def test_StackPlot_t3(self, yticks_minor):
-        ms = load_data()
+        ms = load_ms()
         fig, ax = ms.stackplot(yticks_minor=yticks_minor)
         pyleo.closefig(fig)
         
     @pytest.mark.parametrize('xticks_minor', [True, False])
     def test_StackPlot_t4(self, xticks_minor):
-        ms = load_data()
+        ms = load_ms()
         fig, ax = ms.stackplot(xticks_minor=xticks_minor)
         pyleo.closefig(fig)
+        
+        
+class TestMultipleSeriesCorrelation():
+    ''' Test for MultipleSeries.spectral
+    '''
+    @pytest.mark.parametrize('sig_method', ['ttest','built-in','ar1sim','phaseran','CN'])
+    @pytest.mark.parametrize('number', [2,5])
+    def test_correlation_t0(self, sig_method, number):
+        ''' Test the various significance methods
+        '''
+        ms = load_ms()   
+        corr = ms.correlation(method=sig_method,number=number)
+        
+    @pytest.mark.parametrize('stat', ['linregress','pearsonr','spearmanr','pointbiserialr','kendalltau','weightedtau'])
+    def test_correlation_t1(self, stat, eps=0.2):
+        ''' Test the various statistics
+        '''
+        ms = load_ms() 
+        if stat == 'weightedtau':
+            corr = ms.correlation(statistic=stat)
+        else:
+            corr = ms.correlation(statistic=stat,method='built-in')
         
 class TestMultipleSeriesSpectral():
     ''' Test for MultipleSeries.spectral
@@ -486,7 +508,7 @@ class TestMultipleSeriesSpectral():
         '''Test the spectral function with pre-generated scalogram objects
         '''
         
-        ms = load_data()
+        ms = load_ms()
         if spec_method == 'cwt':
             ms = ms.interp()
         scals = ms.wavelet(method=spec_method)
@@ -494,25 +516,19 @@ class TestMultipleSeriesSpectral():
  
 class TestToCSV:
     def test_to_csv_default(self):
-        soi = pyleo.utils.load_dataset('SOI')
-        nino = pyleo.utils.load_dataset('NINO3')
-        ms = soi & nino
+        ms = load_ms()
         ms.to_csv()
-        os.unlink('MultipleSeries.csv')
+        os.unlink('MultipleSeries.csv') # clean up after yourself!
     def test_to_csv_label(self):
-        soi = pyleo.utils.load_dataset('SOI')
-        nino = pyleo.utils.load_dataset('NINO3')
-        ms = soi & nino
+        ms = load_ms()
         ms.label='enso series'
         ms.to_csv()
-        os.unlink('enso_series.csv') # this check that the file does exist
+        os.unlink('enso_series.csv') # clean up after yourself!
     def test_to_csv_label_path(self):
-        soi = pyleo.utils.load_dataset('SOI')
-        nino = pyleo.utils.load_dataset('NINO3')
-        ms = soi & nino
+        ms = load_ms()
         ms.label='enso wah wah'
         ms.to_csv(path='./enso.csv')
-        os.unlink('enso.csv') # this check that the file does exist
+        os.unlink('enso.csv') # clean up after yourself!
         
 class TestRemove:
     def test_remove(self):


### PR DESCRIPTION
These fix some mistakes/inconsistencies in `Series.correlation()` and  `MultipleSeries.correlation()`. In the process, I discovered that the `statistic` argument had not been enabled in `MultipleSeries.correlation()`, so I fixed that and included a unit test for this and for the significance method. Since its uses `Series.correlation()` under the hood, I did not feel it was necessary to test everything under the Sun, since that is already done for in the `Series.correlation()` unit tests. 
Also fixed a docstring error for `EnsembleSeries.plot_traces()` (argument change)