### PR TITLE
Compare series + fix correlations

### DIFF
--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -536,7 +536,7 @@ class EnsembleSeries(MultipleSeries):
 
             The significance level (0.05 by default)
        
-        method : str, {'ttest','built-in','ar1sim','phaseran'}
+        method : str, {'ttest','built-in','ar1sim','phaseran','CN'}
             method for significance testing. Default is 'ttest' to lower computational cost, but this is not always the best choice
             
         statistic : str
@@ -576,12 +576,13 @@ class EnsembleSeries(MultipleSeries):
 
         See also
         --------
-
-        pyleoclim.utils.correlation.corr_sig : Correlation function
-
+        pyleoclim.core.series.Series.correlation : pairwise correlations
+        
         pyleoclim.utils.correlation.fdr : False Discovery Rate
 
         pyleoclim.core.correns.CorrEns : The correlation ensemble object
+        
+        pyleoclim.core.surrogateseries.SurrogateSeries : surrogate series
 
         Examples
         --------
@@ -612,7 +613,7 @@ class EnsembleSeries(MultipleSeries):
             print(corr_res)
             
         The `print` function tabulates the output, and conveys the p-value according
-        to the correlation test applied ("isospec", by default). To plot the result:
+        to the correlation test applied ("ttest", by default). To plot the result:
         
         .. jupyter-execute::
             
@@ -630,16 +631,22 @@ class EnsembleSeries(MultipleSeries):
             if hasattr(target, 'series_list'):
                 nEns = np.size(target.series_list)
                 if idx < nEns:
-                    value2 = target.series_list[idx].value
-                    time2 = target.series_list[idx].time
+                    ts2 = target.series_list[idx].copy()
+                    #value2 = target.series_list[idx].value
+                    #time2 = target.series_list[idx].time
+                    
                 else:
-                    value2 = target.series_list[idx-nEns].value
-                    time2 = target.series_list[idx-nEns].time
+                    #value2 = target.series_list[idx-nEns].value
+                    #time2 = target.series_list[idx-nEns].time
+                    ts2 = target.series_list[idx-nEns].copy()
             else:
-                value2 = target.value
-                time2 = target.time
-
-            ts2 = Series(time=time2, value=value2, verbose=idx==0, auto_time_params=False)
+                ts2 = target.copy()
+                #value2 = target.value
+                #time2 = target.time
+            
+            #ts2 = target.series_list[idx].copy()
+            #ts2.time = time2; ts2.value = value2 
+            #ts2 = Series(time=time2, value=value2, verbose=idx==0, auto_time_params=False) 
             corr_res = ts1.correlation(ts2, timespan=timespan, method=method,number=number,
                                        statistic=statistic,
                                        settings=settings, mute_pbar=True,

--- a/pyleoclim/core/ensembleseries.py
+++ b/pyleoclim/core/ensembleseries.py
@@ -537,7 +537,7 @@ class EnsembleSeries(MultipleSeries):
             The significance level (0.05 by default)
        
         method : str, {'ttest','built-in','ar1sim','phaseran'}
-            method for significance testing. Default is 'ttest'
+            method for significance testing. Default is 'ttest' to lower computational cost, but this is not always the best choice
             
         statistic : str
             The name of the statistic used to measure the association, to be chosen from a subset of

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -877,7 +877,7 @@ class MultipleSeries:
         if target is None:
             target = self.series_list[0]
 
-        print("Looping over "+ str(len(self.series_list)) +" Series in collection")
+        print(f"Looping over {len(self.series_list)} Series in collection")
         for idx, ts in tqdm(enumerate(self.series_list),  total=len(self.series_list), disable=mute_pbar):
             corr_res = ts.correlation(target, timespan=timespan, alpha=alpha, settings=settings,
                                       method=method, number=number, statistic=statistic,

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -735,6 +735,8 @@ class MultipleSeries:
                     fdr_kwargs=None, common_time_kwargs=None, mute_pbar=False, seed=None):
         ''' Calculate the correlation between a MultipleSeries and a target Series
 
+        This function recursively applies Series.correlation() to members of the MultipleSeries object.
+
         The significance of the correlation is assessed using one of the following methods:
 
         1. 'ttest': T-test adjusted for effective sample size, see [1]
@@ -748,8 +750,7 @@ class MultipleSeries:
         The T-test is a parametric test, hence computationally cheap, but can only be performed in ideal circumstances.
         The others are non-parametric, but their computational requirements scale with the number of simulations.
 
-        The choise of significance test and associated number of Monte-Carlo simulations are passed through the `settings` parameter.
-
+        The False Disvoery Rate method is applied to the assessment of significance when plotting the result. 
         
         Parameters
         ----------
@@ -809,12 +810,23 @@ class MultipleSeries:
         -------
         corr : CorrEns
         
-            the result object
+            the result object, containing the following:
+            - statistic r (array of real numbers)
+            - p-values pval (array of real numbers)
+            - signif (array of booleans)
+            - alpha (significance level)
+            
 
         See also
         --------
+        
+        pyleoclim.core.series.Series.correlation :  Series-level correlation 
 
-        pyleoclim.utils.correlation.corr_sig : Correlation function
+        pyleoclim.utils.correlation.association : SciPy measures of association between variables
+
+        pyleoclim.series.surrogates : parametric and non-parametric surrogates of any Series object
+
+        pyleoclim.multipleseries.common_time : Aligning time axes
 
         pyleoclim.utils.correlation.fdr : FDR function
         

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -17,7 +17,7 @@ import warnings
 import numpy as np
 from copy import deepcopy
 
-from matplotlib.ticker import (MultipleLocator, AutoMinorLocator, FormatStrFormatter)
+from matplotlib.ticker import (AutoMinorLocator, FormatStrFormatter)
 import matplotlib.transforms as transforms
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -750,7 +750,9 @@ class MultipleSeries:
         The T-test is a parametric test, hence computationally cheap, but can only be performed in ideal circumstances.
         The others are non-parametric, but their computational requirements scale with the number of simulations.
 
-        The False Disvoery Rate method is applied to the assessment of significance when plotting the result. 
+        The False Discovery Rate method is applied to the assessment of significance when plotting the result. 
+        
+        If the computation fails, a diagnostic message returns the index and label of the incriminated series. 
         
         Parameters
         ----------
@@ -879,12 +881,19 @@ class MultipleSeries:
 
         print(f"Looping over {len(self.series_list)} Series in collection")
         for idx, ts in tqdm(enumerate(self.series_list),  total=len(self.series_list), disable=mute_pbar):
-            corr_res = ts.correlation(target, timespan=timespan, alpha=alpha, settings=settings,
-                                      method=method, number=number, statistic=statistic,
-                                      common_time_kwargs=common_time_kwargs, seed=seed)
-            r_list.append(corr_res.r)
-            signif_list.append(corr_res.signif)
-            p_list.append(corr_res.p)
+            try:
+                corr_res = ts.correlation(target, timespan=timespan, alpha=alpha, settings=settings,
+                                          method=method, number=number, statistic=statistic,
+                                          common_time_kwargs=common_time_kwargs, seed=seed)
+                r_list.append(corr_res.r)
+                signif_list.append(corr_res.signif)
+                p_list.append(corr_res.p)
+            except:
+                ovrlp = ts.overlap(target)
+                print(f"Computation failed for series #{idx}, {ts.label}; overlap is {ovrlp} {ts.time_unit}")
+                r_list.append(np.nan)
+                signif_list.append(None)
+                p_list.append(np.nan)
             
         r_list = np.array(r_list)
         signif_fdr_list = []

--- a/pyleoclim/core/multipleseries.py
+++ b/pyleoclim/core/multipleseries.py
@@ -825,7 +825,6 @@ class MultipleSeries:
 
         .. jupyter-execute::
 
-            import pyleoclim as pyleo
             from pyleoclim.utils.tsmodel import colored_noise
             import numpy as np
 
@@ -874,7 +873,7 @@ class MultipleSeries:
             r_list.append(corr_res.r)
             signif_list.append(corr_res.signif)
             p_list.append(corr_res.p)
-
+            
         r_list = np.array(r_list)
         signif_fdr_list = []
         fdr_kwargs = {} if fdr_kwargs is None else fdr_kwargs.copy()

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -695,7 +695,7 @@ class Series:
     
     def compare(self,ts,row_clr='palegoldenrod'):
         '''
-        Grapjically compare two Series objects
+        Graphically compare two Series objects
 
         Parameters
         ----------
@@ -707,7 +707,7 @@ class Series:
         fig : Matplotlib figure 
            
         df : pandas dataframe
-            dataframe containing metadata ; identical rows are highlighted
+            dataframe containing metadata ; identical rows are highlighted in Jupyter Notebook
             
         Examples
         --------
@@ -720,7 +720,7 @@ class Series:
             EDC_dD = pyleo.utils.datasets.load_dataset('EDC-dD')
             
             fig, df = GISP2.compare(EDC_dD)
-            df
+            df  # this will display the metadata as a dataframe in a notebook
 
         '''
         time_pars_left = tsbase.time_unit_to_datum_exp_dir(self.time_unit,time_name=self.time_name)

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -710,7 +710,6 @@ class Series:
         pyleoclim.utils.tsbase.overlap : compute length of overlap
 
         '''
-        
         time_pars_left = tsbase.time_unit_to_datum_exp_dir(self.time_unit,time_name=self.time_name)
         time_pars_right = tsbase.time_unit_to_datum_exp_dir(ts.time_unit,time_name=ts.time_name)
         ts_u =  ts.convert_time_unit(time_unit=self.time_unit) if time_pars_left != time_pars_right else ts

--- a/pyleoclim/tests/test_core_EnsembleSeries.py
+++ b/pyleoclim/tests/test_core_EnsembleSeries.py
@@ -18,11 +18,8 @@ import numpy as np
 #from pandas.testing import assert_frame_equal
 
 import pytest
-
 import pyleoclim as pyleo
-from pyleoclim.utils.tsmodel import (
-    colored_noise,
-)
+
 
 # a collection of useful functions
 
@@ -45,16 +42,16 @@ def gen_colored_noise(alpha=1, nt=100, f0=None, m=None, seed=None):
     ''' Generate colored noise
     '''
     t = np.arange(nt)
-    v = colored_noise(alpha=alpha, t=t, f0=f0, m=m, seed=seed)
+    v = pyleo.utils.colored_noise(alpha=alpha, t=t, f0=f0, m=m, seed=seed)
     return t, v
 
 
 # Tests below
 class TestUIEnsembleSeriesCorrelation():
-    def test_correlation_t0(self):
+    def test_correlation_t0(self, nt = 100):
         '''Test for EnsembleSeries.correlation() when the target is a Series
         '''
-        nt = 100
+        
         t0, v0 = gen_colored_noise(nt=nt)
         t0, noise = gen_normal(nt=nt)
 

--- a/pyleoclim/tests/test_core_MultipleSeries.py
+++ b/pyleoclim/tests/test_core_MultipleSeries.py
@@ -25,10 +25,10 @@ from pyleoclim.utils.tsmodel import colored_noise
 
 # a collection of useful functions
 
-def gen_ts(model, nt, alpha, t=None):
+def gen_ts(model='colored_noise',alpha=1, nt=50, f0=None, m=None, seed=None):
     'wrapper for gen_ts in pyleoclim'
-    t, v = pyleo.utils.gen_ts(model=model, nt=nt, alpha=alpha, t=t)
-    ts = pyleo.Series(t, v, verbose=False,auto_time_params=True)
+    t,v = pyleo.utils.gen_ts(model=model,alpha=alpha, nt=nt, f0=f0, m=m, seed=seed)
+    ts=pyleo.Series(t,v, verbose=False, auto_time_params=True)
     return ts
 
 def gen_normal(loc=0, scale=1, nt=100):
@@ -499,6 +499,20 @@ class TestMultipleSeriesCorrelation():
             corr = ms.correlation(statistic=stat)
         else:
             corr = ms.correlation(statistic=stat,method='built-in')
+            
+    def test_correlation_t2(self, rho=0.4, nt = 50):
+        ''' Test that everything works fine even without overlap
+        '''     
+        ts1 = gen_ts(nt=nt, alpha=1,seed=333).standardize()
+        # generate series whose correlation with ts1 should be close to rho:
+        v = rho*ts1.value + np.sqrt(1-rho**2)*np.random.normal(loc=0, scale=1, size=nt)
+        ts2 = pyleo.Series(time=ts1.time, value=v, verbose=False, auto_time_params=True)
+        ts3 = ts1.copy()
+        ts3.time = ts1.time + nt # make time axes disjoint
+        ms = ts2 & ts3
+        corr = ms.correlation(ts1,method='built-in')
+        corr.plot()  # make sure a plot is produced
+        
         
 class TestMultipleSeriesSpectral():
     ''' Test for MultipleSeries.spectral

--- a/pyleoclim/tests/test_core_MultipleSeries.py
+++ b/pyleoclim/tests/test_core_MultipleSeries.py
@@ -409,10 +409,11 @@ class TestMultipleSeriesCommonTime:
         seriesList = []
         n = 100
         for j in range(4):
-            v = gen_ts(model='colored_noise', nt=n, alpha=1, t=time)
+            _, v = pyleo.utils.gen_ts(model='colored_noise', nt=n, alpha=1, t=time)
+            #v = gen_ts(model='colored_noise', nt=n, alpha=1, t=time)
             deleted_idx = np.random.choice(range(np.size(time)), ndel, replace=False)
             tu =  np.delete(time.copy(), deleted_idx)
-            vu =  np.delete(v.value, deleted_idx)
+            vu =  np.delete(v, deleted_idx)
             ts = pyleo.Series(time=tu, value=vu,  value_name='Series_'+str(j+1))
             seriesList.append(ts)
     
@@ -428,10 +429,10 @@ class TestMultipleSeriesCommonTime:
         seriesList = []
         n = 100
         for j in range(4):
-            v = gen_ts(model='colored_noise', nt=n, alpha=1, t=time)
+            _, v = pyleo.utils.gen_ts(model='colored_noise', nt=n, alpha=1, t=time)
             deleted_idx = np.random.choice(range(np.size(time)), ndel, replace=False)
             tu =  np.delete(time.copy(), deleted_idx)
-            vu =  np.delete(v.value, deleted_idx)
+            vu =  np.delete(v, deleted_idx)
             ts = pyleo.Series(time=tu, value=vu,  value_name='Series_'+str(j+1))
             seriesList.append(ts)
     

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -662,7 +662,14 @@ class TestUISeriesCorrelation:
         with pytest.raises(ValueError):  
             corr_res = ts1.correlation(ts2, statistic='kendalltau', method= 'ttest')
                                        
-        
+    def test_correlation_t4(self):
+        '''
+        tests that np.nan is returned if two series don't overlap
+        '''
+        gmst = pyleo.utils.load_dataset('HadCRUT5')
+        ts_13 = pyleo.utils.load_dataset('cenogrid_d13C')
+        corr = gmst.correlation(ts_13)
+        assert corr.r == np.nan
         
 
 class TestUISeriesCausality:

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -696,7 +696,7 @@ class TestUISeriesCorrelation:
         gmst = pyleo.utils.load_dataset('HadCRUT5')
         ts_13 = pyleo.utils.load_dataset('cenogrid_d13C')
         corr = gmst.correlation(ts_13)
-        assert corr.r == np.nan
+        assert np.isnan(corr.r)
         
 
 class TestUISeriesCausality:

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -466,6 +466,33 @@ class TestUISeriesSlice:
 
         assert min(times) == 10
         assert max(times) == 90
+        
+class TestUISeriesOverlap:
+    '''Test for Series.overlap()
+    '''
+    @pytest.mark.parametrize('offset', [0,6])
+    def test_overlap_same_units(self, offset):
+        
+        t = np.linspace(0,5,num=5)
+        v = t
+        ts1 = pyleo.Series(time=t, value=v, time_unit='years', verbose=False)
+        ts2 = pyleo.Series(time=t+offset, value=v, time_unit='years', verbose=False)
+        ovrlp = ts1.overlap(ts2)
+        
+        if offset == 0: 
+            assert ovrlp == 5.0
+        else:
+            assert ovrlp == -1.0    
+    
+    def test_overlap_different_units(self):
+        t1 = np.linspace(0,5,num=5)
+        v = t1
+        ts1 = pyleo.Series(time=t1, value=v, time_unit='ky BP', verbose=False)
+        ts2 = pyleo.Series(time=t1*1000, value=v, time_unit='y BP', verbose=False)
+        ovrlp = ts1.overlap(ts2)
+        
+        assert np.abs(ovrlp-5) < 1e-3
+
 
 class TestSel:
     @pytest.mark.parametrize(

--- a/pyleoclim/tests/test_utils_tsbase.py
+++ b/pyleoclim/tests/test_utils_tsbase.py
@@ -163,3 +163,9 @@ def test_convert_datetime_index_nondt_index(dataframe):
             time_unit, 
             time_name=time_name,
             )
+        
+def test_overlap():
+    t1 = np.linspace(1,10)
+    t2 = np.linspace(2.5,8.5)
+    L = tsbase.overlap(t1, t2)
+    assert L == np.ptp(t2)

--- a/pyleoclim/utils/tsbase.py
+++ b/pyleoclim/utils/tsbase.py
@@ -564,3 +564,26 @@ def resolution(x):
         sign = 'mixed'
         
     return (res, stats, sign)
+
+def overlap(t1,t2):
+    '''
+    Computes length of overlap between two time axes. Negative numbers indicate a lack of overlap. 
+    Note that this does not count the number of overlapping time stamps ; it merely
+    checks that the two axes have a nonzero intersection on the real line. 
+    The amount of points in common depends on how densely sampled these axes are.
+
+    Parameters
+    ----------
+    t1 : array
+        time axis 1
+    t2 : array
+        time axis 2 (though order doesn't matter)
+
+    Returns
+    -------
+    L : length of overlap
+
+    '''
+    tmin = np.max([t1.min(), t2.min()])
+    tmax = np.min([t1.max(), t2.max()])
+    return tmax - tmin


### PR DESCRIPTION
New functions and capabilities to address #619 and #618 

- `Series.correlation()` now checks for overlap, using new function `Series.overlap()`, Returns NaNs for r and p if it cannot compute a correlation due to insufficient overlap
- `MultipleSeries.correlation()` uses try/except to compute correlations between pairs, and returns a helpful error message if it cannot. Useful for diagnosing/debugging
- New function `Series.compare()`, which demos like this (this is what the docstring example should look like once the doc is updated):

![compare_Series](https://github.com/user-attachments/assets/1b899972-77fc-4e26-8779-f36010ff16eb)
