### PR TITLE
Do not load a default Pyleoclim style on init

### DIFF
--- a/pyleoclim/__init__.py
+++ b/pyleoclim/__init__.py
@@ -14,7 +14,7 @@ import pyleoclim.utils as utils
 from .core import *
 
 from .utils.plotting import *
-set_style(style='journal', font_scale=1.4)
+#set_style(style='journal', font_scale=1.4)
 
 # get the version
 from importlib.metadata import version


### PR DESCRIPTION
This pull request is in response to #615 . This was a user request by email who wanted to be able to use the default adaptive style of matplotlib. 

The solution is to not load a style on init of the package. 

PROS:
- Able to use matplotlib default style
- Does not impose a course of action on the user. 

CONS:
- If wanting to use the Pyleoclim styles, will need to be explicitly define at the top of a script/notebook (including our tutorials).

Other alternative considered:
- Have the user change the style back to `matplotlib`. Unfortunately, this result in a non-adaptive plot. Here is the difference on the Cenogrid data. 

1. Pyleoclim style
![image](https://github.com/user-attachments/assets/ff5454e6-9a6c-4ef8-8f97-9b8bdcd796c1)

2. When style is changed to `matplotlib`
![image](https://github.com/user-attachments/assets/98eb33ac-1f0b-498a-a04c-1def056d8d5a)

3. When no style is set by default in the Pyleoclim package (this pull request); therefore using matplotlib adaptive library
![image](https://github.com/user-attachments/assets/64954400-3401-4596-8011-8eb4e8e7a854)




