### PR TITLE
Simple change to documentation to make explicitly clear where to change parameter values and fix to geo mapping function

### DIFF
--- a/pyleoclim/core/geoseries.py
+++ b/pyleoclim/core/geoseries.py
@@ -344,7 +344,25 @@ class GeoSeries(Series):
             Draws major lakes.
             If a dictionary of formatting arguments is supplied (e.g. color, alpha), will draw according to specifications.
             Default is off (False).
+        
+        fig : matplotlib.pyplot.figure, optional
+            See matplotlib.pyplot.figure <https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.pyplot.figure.html#matplotlib-pyplot-figure>_.
+            The default is None.
 
+        gridspec_slot : Gridspec slot, optional
+            If generating a map for a multi-plot, pass a gridspec slot.
+            The default is None.
+        
+        title : string
+            Title for the plot. Default is None
+        
+        size : string, optional
+            Grouping variable that will produce points with different sizes. Expects to be associated with numeric values (e.g., 'elevation' has values). Any data without a value for the size variable will be filtered out.
+            The default is None.
+        
+        edgecolor : color (string) or list of rgba tuples, optional
+            Color of marker edge. The default is 'w'.
+            
         figsize : list or tuple, optional
             The size of the figure. The default is None.
 
@@ -361,6 +379,18 @@ class GeoSeries(Series):
 
         scatter_kwargs : dict, optional
             Parameters for the scatter plot. The default is None.
+        
+        cmap : string or list, optional
+            Matplotlib supported colormap id or list of colors for creating a colormap. See `choosing a matplotlib colormap <https://matplotlib.org/3.5.0/tutorials/colors/colormaps.html>`_.
+            The default is None.
+        
+        colorbar : bool, optional
+            Whether the draw a colorbar on the figure if the data associated with hue are numeric.
+            Default is True.
+        
+        gridspec_kwargs : dict, optional
+            Function assumes the possibility of a colorbar, map, and legend. A list of floats associated with the keyword `width_ratios` will assume the first (index=0) is the relative width of the colorbar, the second to last (index = -2) is the relative width of the map, and the last (index = -1) is the relative width of the area for the legend.
+            For information about Gridspec configuration, refer to `Matplotlib documentation <https://matplotlib.org/3.5.0/api/_as_gen/matplotlib.gridspec.GridSpec.html#matplotlib.gridspec.GridSpec>`_. The default is None.
 
         legend :  bool; {True, False}, optional
             Whether to plot the legend. The default is True.
@@ -406,8 +436,10 @@ class GeoSeries(Series):
 
 
         '''
+        scatter_kwargs = {} if scatter_kwargs is None else scatter_kwargs.copy()
+        
         if markersize != None:
-            scatter_kwargs['markersize'] = markersize
+            scatter_kwargs['s'] = markersize
             
         if type(title)==bool:
             if title == False:

--- a/pyleoclim/core/multivardecomp.py
+++ b/pyleoclim/core/multivardecomp.py
@@ -187,6 +187,8 @@ class MultivariateDecomp:
         
         Includes: The temporal coefficient (PC or similar), its spectrum, and the loadings (EOF or similar), possibly geolocated. 
         If the object does not have geolocation information, a spaghetti plot of the standardized series is displayed.
+        
+        To see how to use the different parameters, consult the following tutorial: http://linked.earth/PyleoTutorials/notebooks/L2_principal_component_analysis.html
 
         Parameters
         ----------
@@ -246,7 +248,7 @@ class MultivariateDecomp:
             - scalar_mappable: matplotlib.cm.ScalarMappable; can be used to pass a matplotlib scalar mappable. See pyleoclim.utils.plotting.make_scalar_mappable for documentation on using the Pyleoclim utility, or the `Matplotlib tutorial on customizing colorbars <https://matplotlib.org/stable/users/explain/colors/colorbar_only.html>`_.
 
         scatter_kwargs : dict, optional
-            Optional arguments configuring how data are plotted on a map. See description of scatter_kwargs in pyleoclim.utils.mapping.scatter_map
+            Optional arguments configuring how data are plotted on a map. This allows you to configure information about the style of markers (e.g., triangle, squares, circles), their size (through `markersize`), edgecolor, etc...) See description of scatter_kwargs in pyleoclim.utils.mapping.scatter_map
 
         hue : str, optional
             (only applicable if using scatter map) Variable associated with color coding for points plotted on map. May correspond to a continuous or categorical variable.
@@ -258,7 +260,7 @@ class MultivariateDecomp:
 
         marker : string, optional
             (only applicable if using scatter map) Grouping variable that will produce points with different markers. Can have a numeric dtype but will always be treated as categorical.
-            The default is None, which will produce circle markers. Alternatively, pass the name of a categorical variable, e.g. 'archiveType'. If 'archiveType' is specified, will attempt to use pyleoclim archiveType markers mapping, defaulting to '?' where values are unavailable.
+            The default is None, which will produce circle markers. Alternatively, pass the name of a categorical variable, e.g. 'archiveType'. If 'archiveType' is specified, will attempt to use pyleoclim archiveType markers mapping, defaulting to '?' where values are unavailable. Caution: this is different from the `marker` argument in matplotlib. If you want to specify a marker style (e.g., cirle, square, triangle, use scatter_kwargs)
 
             
         Returns

--- a/pyleoclim/tests/test_core_GeoSeries.py
+++ b/pyleoclim/tests/test_core_GeoSeries.py
@@ -167,6 +167,10 @@ class TestUIGeoSeriesMap():
             ax['map'].get_title() == 'Untitled'
         pyleo.closefig(fig)
         pyleo.closefig(fig)
+    
+    def test_map_t2(self,pinkgeoseries):
+        ts = pinkgeoseries
+        fig,ax = ts.map(markersize=100)
         
         
 def test_segment():


### PR DESCRIPTION
Updated documentation for `PCA.modeplot()` and `GeoSeries.mapping` to make sure that each parameter was described. Small  fix to the `GeoSeries.mapping` for marker size handling. Also added a test to catch this error in the future. 

Fix for #578 