### PR TITLE
Add critical value of the association measure to Series.correlation()

### DIFF
--- a/pyleoclim/core/corr.py
+++ b/pyleoclim/core/corr.py
@@ -39,10 +39,13 @@ class Corr:
     Parameters
     ----------
     r: float
-        the correlation coefficient
-
+        the metric of association (see https://docs.scipy.org/doc/scipy/reference/stats.html#association-correlation-tests)
+             
     p: float
         the p-value
+    
+    r_crit : float
+        critical value for significance
 
     p_fmt_td: float
         the threshold for p-value formatting (0.01 by default, i.e., if p<0.01, will print "< 0.01" instead of "0")
@@ -64,9 +67,10 @@ class Corr:
     pyleoclim.utils.correlation.fdr : FDR function
     '''
 
-    def __init__(self, r, p, signif, alpha, p_fmt_td=0.01, p_fmt_style='exp'):
+    def __init__(self, r, p, r_crit, signif, alpha, p_fmt_td=0.01, p_fmt_style='exp'):
         self.r = r
         self.p = p
+        self.r_crit = r_crit
         self.p_fmt_td = p_fmt_td
         self.p_fmt_style = p_fmt_style
         self.signif = bool(signif) # coerce as Boolean
@@ -84,7 +88,8 @@ class Corr:
         formatted_p = pval_format(self.p, threshold=self.p_fmt_td, style=self.p_fmt_style)
 
         table = {
-            'correlation': [self.r],
+            'statistic': [self.r],
+            'critical value': [self.r_crit],
             'p-value': [formatted_p],
             f'signif. (α: {self.alpha})': [self.signif],
         }

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3690,7 +3690,9 @@ class Series:
             the result object, containing
 
             - r : float
-                correlation coefficient
+                association metric (typically, correlation coefficient)
+            - r_crit : float
+                critical value of the statistic
             - p : float
                 the p-value
             - signif : bool
@@ -3801,6 +3803,7 @@ class Series:
                     stat = res[0]
                     pval = res.pvalue if len(res) > 1 else np.nan
                     signif = pval <= alpha
+                    
             elif method in supported_surrogates:      
                 if 'nsim' in settings.keys(): # for legacy reasons
                     raise DeprecationWarning("The number of simulations is now governed by the parameter `number`. nsim will be removed in an upcoming release")
@@ -3831,9 +3834,10 @@ class Series:
             warnings.warn(f'The series have insufficient overlap ({ovrlp} {self.time_unit}); default values assigned to object',UserWarning, stacklevel=2)
             stat = np.nan
             pval = np.nan
+            stat_crit = np.nan
             signif = None
             
-        corr = Corr(stat, pval, signif, alpha) # assemble Correlation result object
+        corr = Corr(stat, pval, stat_crit, signif, alpha) # assemble Correlation result object
         return corr
 
     def causality(self, target_series, method='liang', timespan=None, settings=None, common_time_kwargs=None):

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3803,6 +3803,7 @@ class Series:
                     stat = res[0]
                     pval = res.pvalue if len(res) > 1 else np.nan
                     signif = pval <= alpha
+                    stat_crit = np.nan
                     
             elif method in supported_surrogates:      
                 if 'nsim' in settings.keys(): # for legacy reasons
@@ -3829,7 +3830,10 @@ class Series:
                 # establish significance
                 signif = pval <= alpha
                 # critical value
-                stat_crit = np.quantile(stat_surr, alpha)
+                if stat < 0:
+                    stat_crit = np.quantile(stat_surr, alpha)
+                else:
+                    stat_crit = np.quantile(stat_surr, 1-alpha)
             else:
                 raise ValueError(f'Unknown method: {method}. Look up documentation for a wiser choice.')
         else:

--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -3692,7 +3692,7 @@ class Series:
             - r : float
                 association metric (typically, correlation coefficient)
             - r_crit : float
-                critical value of the statistic
+                critical value of the statistic (unless 'method' = 'built-in', in which case this quantity is not computed, and output as np.nan)
             - p : float
                 the p-value
             - signif : bool
@@ -3790,7 +3790,7 @@ class Series:
     
             if method == 'ttest':
                 if statistic == 'pearsonr':
-                    stat, signf, pval = corrutils.corr_ttest(ts0.value, ts1.value, alpha=alpha)
+                    stat, signf, pval, stat_crit = corrutils.corr_ttest(ts0.value, ts1.value, alpha=alpha)
                     signif = bool(signf)
                 else:
                     raise ValueError(f"The adjusted T-test only applies to Pearson's r; got {statistic}")
@@ -3828,13 +3828,15 @@ class Series:
                 pval = np.sum(np.abs(stat_surr) >= np.abs(stat)) / number
                 # establish significance
                 signif = pval <= alpha
+                # critical value
+                stat_crit = np.quantile(stat_surr, alpha)
             else:
                 raise ValueError(f'Unknown method: {method}. Look up documentation for a wiser choice.')
         else:
             warnings.warn(f'The series have insufficient overlap ({ovrlp} {self.time_unit}); default values assigned to object',UserWarning, stacklevel=2)
             stat = np.nan
-            pval = np.nan
             stat_crit = np.nan
+            pval = np.nan
             signif = None
             
         corr = Corr(stat, pval, stat_crit, signif, alpha) # assemble Correlation result object

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -28,6 +28,7 @@ test_dirpath = pathlib.Path(__file__).parent.absolute()
 
 import pyleoclim as pyleo
 import pyleoclim.utils.tsbase as tsbase
+import pyleoclim.utils.tsmodel as tsmodel
 
 
 
@@ -697,6 +698,31 @@ class TestUISeriesCorrelation:
         ts_13 = pyleo.utils.load_dataset('cenogrid_d13C')
         corr = gmst.correlation(ts_13)
         assert np.isnan(corr.r)
+        
+    def test_correlation_t5(self):
+        '''
+        Check that `ttest` method returns an analytically-sensible critical value
+        '''
+        ts=pyleo.utils.load_dataset('SOI').standardize()
+        rho = 0.6; tcrit = 1.96  # use quantile of standard normal bc nu is so large
+        # generate series whose correlation with ts1 should be close to rho:
+        v2 = rho*ts.value + np.sqrt(1-rho**2)*np.random.normal(loc=0, scale=1, size=len(ts.time))
+        ts2 = pyleo.Series(time=ts.time, value=v2, verbose=False, auto_time_params=True)
+        corr_res = ts.correlation(ts2, method= 'ttest')
+        import scipy.stats as stats
+        g1 = tsmodel.ar1_fit_evenly(ts.value)
+        g2 = tsmodel.ar1_fit_evenly(v2)
+        N = len(ts.value)
+        
+        Ney1 = N * (1-g1) / (1+g1)
+        Ney2 = N * (1-g2) / (1+g2)
+        
+        Ne = stats.mstats.gmean([Ney1,Ney2])
+        df = Ne -2
+        
+        r_crit = np.sqrt(tcrit**2/(df*(1+tcrit**2)))
+                  
+        assert np.abs((corr_res.r_crit -r_crit)/r_crit) < 0.1
         
 
 class TestUISeriesCausality:

--- a/pyleoclim/tests/test_core_Series.py
+++ b/pyleoclim/tests/test_core_Series.py
@@ -724,6 +724,24 @@ class TestUISeriesCorrelation:
                   
         assert np.abs((corr_res.r_crit -r_crit)/r_crit) < 0.1
         
+    @pytest.mark.parametrize('sig_method', ['ttest','built-in','ar1sim','phaseran','CN'])
+    def test_correlation_t6(self, sig_method, number=10, eps=0.1):
+        ''' Test the various significance methods
+        '''
+        nt = 100
+        rho = 0.4 # target correlation
+        ts1 = gen_ts(nt=nt,alpha=1,seed=333).standardize()
+        # generate series whose correlation with ts1 should be close to rho:
+        v = rho*ts1.value + np.sqrt(1-rho**2)*np.random.normal(loc=0, scale=1, size=nt)
+        ts2 = pyleo.Series(time=ts1.time, value=v, verbose=False, auto_time_params=True)
+
+        corr_res = ts1.correlation(ts2, method= sig_method, number=number)
+        
+        if sig_method == 'built-in':
+            assert np.isnan(corr_res.r_crit)
+        else:
+            assert np.isfinite(corr_res.r_crit)
+        
 
 class TestUISeriesCausality:
     ''' Test Series.causality()

--- a/pyleoclim/utils/correlation.py
+++ b/pyleoclim/utils/correlation.py
@@ -233,7 +233,7 @@ def corr_ttest(y1, y2, alpha=0.05, df_min=10):
     pval = 2 * stats.t.cdf(-np.abs(t), df)
     
     tcrit = stats.t.ppf(1-alpha,df)
-    rcrit = np.sign(r)*tcrit*np.sqrt(1/(1+(df/tcrit)**2))
+    rcrit = np.sign(r)*tcrit*np.sqrt(1/(1+df/tcrit**2))
 
     signif = pval <= alpha
 

--- a/pyleoclim/utils/correlation.py
+++ b/pyleoclim/utils/correlation.py
@@ -228,12 +228,12 @@ def corr_ttest(y1, y2, alpha=0.05, df_min=10):
     assert Ne >= df_min, 'Too few effective d.o.f. to apply this method!'
 
     df = Ne - 2
-    t = np.abs(r) * np.sqrt(df/(1-r**2))
-
-    pval = 2 * stats.t.cdf(-np.abs(t), df)
+    t = r*np.sqrt(df/(1-r**2))
+    
+    pval = stats.t.cdf(-np.abs(t), df) # one sided T-test ; leverage symmetry of T distribution
     
     tcrit = stats.t.ppf(1-alpha,df)
-    rcrit = np.sign(r)*tcrit*np.sqrt(1/(1+df/tcrit**2))
+    rcrit = np.sign(r)*np.sqrt(tcrit**2/(df*(1+tcrit**2)))
 
     signif = pval <= alpha
 


### PR DESCRIPTION
have not added the same to CorrEns bc 1) it is not obvious how to do so and 2) I could see a use case for it. 

Addresses issue #625 