### PR TITLE
enable multiprocessing for spectral, wavelet and cross-wavelet analysis

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,4 +20,5 @@ dependencies:
   - pytest
   - pip:
     - pyhht
+    - dill
     - '-e .'

--- a/pyleoclim/core/psds.py
+++ b/pyleoclim/core/psds.py
@@ -1517,6 +1517,7 @@ class MultiplePSD:
         --------
 
         .. jupyter-execute::
+            
             nn = 30 # number of noise realizations
             nt = 500 # timeseries length
             psds = []

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "beautifulsoup4",
         "scipy",
         "requests",
+        "dill",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.11",
 )


### PR DESCRIPTION
Enable multiprocessing for the significance test. Speed up is about x6 on Mac M3. 

1. Functions that were added at the top of modules are helper function that NEED to be outside a class to function. They have an `_` at the beginning so they are set to private and won't appear anywhere. 
2. The Series class needs to be imported inside the functions for coherence for pickling issues. Do not remove the line
3. For coherence, dill was necessary (Series is not pickable apparently). 
4. General clean up to the code base since I was at it. 