### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,12 +14,10 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: doc_build/conf.py
+  fail_on_warning: false
 
 conda:
   environment: doc_build/rtd_env.yml
-
-sphinx:
-  fail_on_warning: false
 
 formats: []
 


### PR DESCRIPTION
There was an issue where the sphinx key was used twice in the file and it wasn't reading the first part properly. This should fix the readthedocs config issue