### PR TITLE
Fix detrending in preprocess()

### DIFF
--- a/pyleoclim/utils/tsutils.py
+++ b/pyleoclim/utils/tsutils.py
@@ -1807,7 +1807,9 @@ def preprocess(ys, ts, detrend=False, sg_kwargs=None,
     if detrend == 'none' or detrend is False or detrend is None:
         ys_d = ys
     else:
-        ys_d = detrend(ys, ts, method=detrend, sg_kwargs=sg_kwargs)
+        # Circumvent naming conflict between detrend the function and detrend the argument
+        from . import detrend as detrend_ts
+        ys_d = detrend_ts(ys, ts, method=detrend, sg_kwargs=sg_kwargs)
 
     if standardize:
         res, _, _ = std(ys_d)

--- a/pyleoclim/utils/tsutils.py
+++ b/pyleoclim/utils/tsutils.py
@@ -1809,7 +1809,7 @@ def preprocess(ys, ts, detrend=False, sg_kwargs=None,
     else:
         # Circumvent naming conflict between detrend the function and detrend the argument
         from . import detrend as detrend_ts
-        ys_d = detrend_ts(ys, ts, method=detrend, sg_kwargs=sg_kwargs)
+        ys_d = detrend_ts(ys, ts, method=detrend, sg_kwargs=sg_kwargs)[0]
 
     if standardize:
         res, _, _ = std(ys_d)


### PR DESCRIPTION
`pyleoclim.utils.tsutils.preprocess()` fails when a `detrend` method is specified as string. This is because the `preprocess()` argument and the `detrend()` method are named identically, therefore `detrend` within `preprocess()` refers to the string argument and thus fails when called. This PR renames the `detrend()` method locally to circumvent the conflict. The `preprocess()` method is used in all spectral analysis methods.

Example code:
```python
import pyleoclim
from pyleoclim.utils.tsutils import preprocess

ts = pyleoclim.utils.load_dataset("LR04")
preprocess(ts.value, ts.time, detrend="linear")
```

Before, fails with:
```
Traceback (most recent call last):
  File "/Users/dstiller/dev/pyleoclim/pyleoclim/tests/examples.py", line 5, in <module>
    preprocess(ts.value, ts.time, detrend="linear")
  File "/Users/dstiller/dev/pyleoclim/pyleoclim/utils/tsutils.py", line 1812, in preprocess
    ys_d = detrend(ys, ts, method=detrend, sg_kwargs=sg_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'str' object is not callable
```

There are other ways to fix this issue, such as renaming the argument or the `detrend()` function, but this way the API is not changed.