### PR TITLE
Fix filtering with ARIMA padding

### DIFF
--- a/pyleoclim/core/series.py
+++ b/pyleoclim/core/series.py
@@ -1684,7 +1684,8 @@ class Series:
             if window_length % 2 == 0:
                 window_length += 1   # window length needs to be an odd integer
             args['savitzky-golay'] = {'window_length': window_length}
-            args[method].update(kwargs)
+        
+        args[method].update(kwargs)
 
         new_val = method_func[method](y, **args[method])
         new.value = new_val + mu # restore the mean

--- a/pyleoclim/utils/filter.py
+++ b/pyleoclim/utils/filter.py
@@ -12,7 +12,7 @@ __all__ = [
 ]
 
 import numpy as np
-import statsmodels.api as sm
+from statsmodels.tsa.arima.model import ARIMA
 from scipy import signal
 
 from .tsbase import (
@@ -173,24 +173,24 @@ def ts_pad(ys,ts,method = 'reflect', params=(1,0,0), reflect_type = 'odd',padFra
     pyleoclim.utils.filter.firwin : Applies a Finite Impulse Response filter with frequency fc, with padding
     
     """
-    padLength =  np.round(len(ts)*padFrac).astype(np.int64)
+    padLength = int(np.round(len(ts)*padFrac))
 
     if is_evenly_spaced(ts)==False:
         raise ValueError("ts needs to be composed of even increments")
     else:
-        dt = np.diff(ts)[0] # computp time interval
+        dt = np.diff(ts)[0] # compute time interval
     
     #time axis
     tp = np.arange(ts[0]-padLength*dt,ts[-1]+padLength*dt+dt,dt)
     
     if method == 'ARIMA':
         # fit ARIMA model
-        fwd_mod = sm.tsa.ARIMA(ys,params).fit()  # model with time going forward
-        bwd_mod = sm.tsa.ARIMA(np.flip(ys,0),params).fit()  # model with time going backwards
+        fwd_mod = ARIMA(ys, order=params).fit()  # model with time going forward
+        bwd_mod = ARIMA(np.flip(ys,0), order=params).fit()  # model with time going backwards
 
         # predict forward & backward
-        fwd_pred  = fwd_mod.forecast(padLength); yf = fwd_pred[0]
-        bwd_pred  = bwd_mod.forecast(padLength); yb = np.flip(bwd_pred[0],0)
+        yf = fwd_mod.forecast(padLength)
+        yb = np.flip(bwd_mod.forecast(padLength))
 
         # extend time series
         yp = np.empty(len(tp))


### PR DESCRIPTION
Filtering a Series with ARIMA padding did not work because
- the pad argument wasn't passed from Series.filter to the specific filtering method, and
- the ARIMA methods in statsmodels changed their signature (fit and forecast).

This PR fixes both issues.